### PR TITLE
Add dev container configuration for Momentum

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,0 +1,22 @@
+# syntax=docker/dockerfile:1
+ARG VARIANT="8.0-bookworm-slim"
+FROM mcr.microsoft.com/devcontainers/dotnet:${VARIANT}
+
+# Install base tooling required across development, build, test and security scan stages
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends \
+        build-essential \
+        curl \
+        git \
+        jq \
+        make \
+        unzip \
+        wget \
+    && rm -rf /var/lib/apt/lists/*
+
+# Allow Playwright to install browsers once inside the container when tests require it
+ENV PLAYWRIGHT_BROWSERS_PATH=/ms-playwright
+
+# Keep parity with local development expectations
+ENV ASPNETCORE_ENVIRONMENT=Development \
+    NODE_ENV=development

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,96 @@
+{
+  "$schema": "https://raw.githubusercontent.com/devcontainers/spec/main/schemas/devContainer.schema.json",
+  "name": "Momentum Platform",
+  "build": {
+    "dockerfile": "Dockerfile",
+    "context": "..",
+    "args": {
+      "VARIANT": "8.0-bookworm-slim"
+    }
+  },
+  "features": {
+    "ghcr.io/devcontainers/features/node:1": {
+      "version": "20",
+      "pnpmVersion": "none",
+      "installYarnUsingApt": false
+    },
+    "ghcr.io/devcontainers/features/docker-outside-of-docker:1": {
+      "version": "latest"
+    }
+  },
+  "remoteUser": "vscode",
+  "containerEnv": {
+    "DOTNET_CLI_TELEMETRY_OPTOUT": "1",
+    "DOTNET_NOLOGO": "1"
+  },
+  "forwardPorts": [4200, 5000, 5001, 9090],
+  "portsAttributes": {
+    "4200": {
+      "label": "Angular dev server"
+    },
+    "5000": {
+      "label": "Backend HTTP"
+    },
+    "5001": {
+      "label": "Backend HTTPS"
+    },
+    "9090": {
+      "label": "Observability / Grafana"
+    }
+  },
+  "postCreateCommand": "bash .devcontainer/scripts/post-create.sh",
+  "postStartCommand": "bash .devcontainer/scripts/post-start.sh",
+  "mounts": [
+    "source=${localEnv:HOME}/.aspnet/https,target=/home/vscode/.aspnet/https,type=bind"
+  ],
+  "customizations": {
+    "vscode": {
+      "settings": {
+        "dotnet.defaultSolution": "Momentum.sln",
+        "editor.formatOnSave": true,
+        "files.trimTrailingWhitespace": true,
+        "[typescript]": {
+          "editor.defaultFormatter": "esbenp.prettier-vscode"
+        }
+      },
+      "extensions": [
+        "ms-dotnettools.csdevkit",
+        "angular.ng-template",
+        "esbenp.prettier-vscode",
+        "dbaeumer.vscode-eslint",
+        "ms-azuretools.vscode-docker"
+      ],
+      "tasks": {
+        "version": "2.0.0",
+        "tasks": [
+          {
+            "label": "Build (make)",
+            "type": "shell",
+            "command": "make build",
+            "group": "build",
+            "problemMatcher": []
+          },
+          {
+            "label": "Test (make)",
+            "type": "shell",
+            "command": "make test",
+            "group": "test",
+            "problemMatcher": []
+          },
+          {
+            "label": "Security scan",
+            "type": "shell",
+            "command": "dotnet list Momentum.sln package --vulnerable --include-transitive && npm audit --prefix src/web-core",
+            "problemMatcher": []
+          },
+          {
+            "label": "Angular lint",
+            "type": "shell",
+            "command": "npm run lint --prefix src/web-core",
+            "problemMatcher": []
+          }
+        ]
+      }
+    }
+  }
+}

--- a/.devcontainer/scripts/post-create.sh
+++ b/.devcontainer/scripts/post-create.sh
@@ -1,0 +1,17 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Restore backend dependencies
+if [ -f Momentum.sln ]; then
+  dotnet restore Momentum.sln
+fi
+
+# Restore frontend dependencies
+if [ -f src/web-core/package.json ]; then
+  npm install --prefix src/web-core
+fi
+
+# Prepare Playwright browsers if end-to-end tests are present
+if [ -d tests ]; then
+  npx --yes playwright install --with-deps || true
+fi

--- a/.devcontainer/scripts/post-start.sh
+++ b/.devcontainer/scripts/post-start.sh
@@ -1,0 +1,16 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Ensure the developer user owns the HTTPS development certificates folder if mounted
+if [ -d /home/vscode/.aspnet/https ]; then
+  sudo chown -R vscode:vscode /home/vscode/.aspnet/https || true
+fi
+
+# Display quick usage summary
+cat <<'MSG'
+Momentum devcontainer ready.
+- make build       → build backend and frontend
+- make test        → run unit tests
+- npm audit        → audit frontend packages
+- dotnet list ...  → audit backend packages
+MSG

--- a/README.md
+++ b/README.md
@@ -26,6 +26,15 @@ Oppure con Aspire:
 dotnet run --project src/AppHost/Momentum.AppHost.csproj
 ```
 
+## Devcontainer
+
+Il repository include una configurazione [Dev Container](https://containers.dev/) pronta all'uso nella cartella `.devcontainer/`. Consente di avere un ambiente di sviluppo coerente per build, test e controlli di sicurezza.
+
+1. Apri la cartella del progetto con VS Code e scegli `Reopen in Container`.
+2. Al termine del provisioning verranno ripristinati automaticamente i pacchetti .NET e Angular.
+3. Sono già disponibili i task `Build (make)`, `Test (make)` e `Security scan` per eseguire rapidamente build, test e audit dipendenze.
+4. Le porte principali (4200, 5000, 5001, 9090) vengono esposte automaticamente verso l'host.
+
 ## Servizi
 
 | Servizio | Descrizione |

--- a/docs/devcontainer.md
+++ b/docs/devcontainer.md
@@ -1,0 +1,31 @@
+# Devcontainer Momentum
+
+La configurazione del Dev Container permette di avere un ambiente riproducibile per lo sviluppo quotidiano della piattaforma Momentum.
+
+## Contenuto principale
+
+- **Dockerfile personalizzato** basato su `mcr.microsoft.com/devcontainers/dotnet` con tool di base (`make`, `jq`, `git`, `curl`) utili per build, test e analisi sicurezza.
+- **Feature Node 20** per supportare il frontend Angular 19 e gli script npm.
+- **Supporto Docker-in-Docker** per eseguire `docker compose` direttamente dal container di sviluppo.
+- **Script post-create** che ripristina i pacchetti .NET/Angular e prepara Playwright per gli end-to-end test.
+- **Task VS Code** preconfigurati per `make build`, `make test`, audit dipendenze (`dotnet list ...` e `npm audit`) e linting Angular.
+
+## Utilizzo
+
+1. Installa l'estensione [Dev Containers](https://marketplace.visualstudio.com/items?itemName=ms-vscode-remote.remote-containers) in VS Code.
+2. Apri la cartella del repository e scegli `Dev Containers: Reopen in Container`.
+3. Attendi il completamento dello script di bootstrap. Al termine avrai:
+   - dipendenze .NET e npm già ripristinate;
+   - Playwright pronto per gli end-to-end test (`make e2e`);
+   - porte 4200/5000/5001/9090 inoltrate verso l'host per frontend, backend e osservabilità.
+4. Utilizza i task disponibili (`Terminal > Run Task...`) per build, test o security scan.
+
+## Script disponibili
+
+- `.devcontainer/scripts/post-create.sh` – provisioning iniziale (restore pacchetti, setup Playwright).
+- `.devcontainer/scripts/post-start.sh` – normalizza permessi certificati HTTPS e mostra i comandi principali.
+
+## Note
+
+- I certificati di sviluppo HTTPS sono montati dalla macchina host in `/home/vscode/.aspnet/https` per mantenere la compatibilità con ASP.NET.
+- Per aggiornare Playwright o installare browser aggiuntivi eseguire `npx playwright install --with-deps` all'interno del container.


### PR DESCRIPTION
## Summary
- add a dev container definition based on the .NET 8 image with Node.js, Docker access, and setup scripts
- configure VS Code tasks for build, test, lint, and security checks inside the container
- document how to use the development container in the README and dedicated docs page

## Testing
- not run (configuration changes only)


------
https://chatgpt.com/codex/tasks/task_e_68e93b9f29088333860f88f48ac47b47