### PR TITLE
Fix test project references to main services

### DIFF
--- a/tests/Notifier/Notifier.Api.Integration/Notifier.Api.Integration.csproj
+++ b/tests/Notifier/Notifier.Api.Integration/Notifier.Api.Integration.csproj
@@ -9,6 +9,6 @@
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.8.0" />
   </ItemGroup>
   <ItemGroup>
-    <ProjectReference Include="../../src/services/notifier/Notifier.Api/Notifier.Api.csproj" />
+    <ProjectReference Include="../../../src/services/notifier/Notifier.Api/Notifier.Api.csproj" />
   </ItemGroup>
 </Project>

--- a/tests/Streamer/Streamer.Application.Tests/Streamer.Application.Tests.csproj
+++ b/tests/Streamer/Streamer.Application.Tests/Streamer.Application.Tests.csproj
@@ -10,7 +10,7 @@
     <PackageReference Include="Moq" Version="4.20.69" />
   </ItemGroup>
   <ItemGroup>
-    <ProjectReference Include="../../src/services/streamer/Streamer.Application/Streamer.Application.csproj" />
-    <ProjectReference Include="../../src/services/streamer/Streamer.Domain/Streamer.Domain.csproj" />
+    <ProjectReference Include="../../../src/services/streamer/Streamer.Application/Streamer.Application.csproj" />
+    <ProjectReference Include="../../../src/services/streamer/Streamer.Domain/Streamer.Domain.csproj" />
   </ItemGroup>
 </Project>


### PR DESCRIPTION
## Summary
- correct integration and unit test project references to point at the service projects under src/services
- ensure Visual Studio can locate the referenced service projects when loading the solution

## Testing
- not run (dotnet CLI unavailable in container)


------
https://chatgpt.com/codex/tasks/task_e_68e95a01185083339b048862bc6bbf51
- Fixes #16 (commit 34cd025)