### PR TITLE
Fix central package version usage

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -3,14 +3,39 @@
     <ManagePackageVersionsCentrally>true</ManagePackageVersionsCentrally>
   </PropertyGroup>
   <ItemGroup>
-    <PackageVersion Include="OpenTelemetry" Version="1.8.0" />
-    <PackageVersion Include="OpenTelemetry.Extensions.Hosting" Version="1.8.0" />
-    <PackageVersion Include="OpenTelemetry.Instrumentation.AspNetCore" Version="1.8.0" />
-    <PackageVersion Include="OpenTelemetry.Exporter.Prometheus.AspNetCore" Version="1.8.0" />
-    <PackageVersion Include="OpenTelemetry.Exporter.Otlp" Version="1.8.0" />
+    <PackageVersion Include="Apache.Ignite" Version="2.16.0" />
+    <PackageVersion Include="Aspire.Hosting" Version="8.0.0-preview.5.23620.2" />
+    <PackageVersion Include="Aspire.Hosting.Dapr" Version="8.0.0-preview.5.23620.2" />
+    <PackageVersion Include="Aspire.Hosting.Kafka" Version="8.0.0-preview.5.23620.2" />
+    <PackageVersion Include="Aspire.Hosting.PostgreSQL" Version="8.0.0-preview.5.23620.2" />
+    <PackageVersion Include="Aspire.Microsoft.AspNetCore.Hosting" Version="8.0.0-preview.5.23620.2" />
+    <PackageVersion Include="Azure.Communication.Email" Version="1.1.0" />
+    <PackageVersion Include="Confluent.Kafka" Version="2.4.0" />
+    <PackageVersion Include="Dapr.AspNetCore" Version="1.13.0" />
+    <PackageVersion Include="Dapr.Client" Version="1.13.0" />
+    <PackageVersion Include="Grpc.AspNetCore" Version="2.57.0" />
+    <PackageVersion Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="8.0.10" />
+    <PackageVersion Include="Microsoft.AspNetCore.Mvc.Testing" Version="8.0.0" />
+    <PackageVersion Include="Microsoft.AspNetCore.SignalR" Version="1.1.0" />
+    <PackageVersion Include="Microsoft.AspNetCore.SignalR.Client" Version="8.0.0" />
+    <PackageVersion Include="Microsoft.Extensions.Diagnostics.HealthChecks" Version="8.0.0" />
+    <PackageVersion Include="Microsoft.Extensions.Hosting" Version="8.0.0" />
+    <PackageVersion Include="Microsoft.Extensions.Options.ConfigurationExtensions" Version="8.0.0" />
+    <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="17.8.0" />
+    <PackageVersion Include="Moq" Version="4.20.69" />
+    <PackageVersion Include="Npgsql" Version="8.0.3" />
+    <PackageVersion Include="OpenFeature" Version="1.8.0" />
+    <PackageVersion Include="OpenFeature.Contrib.Providers.Memory" Version="1.2.0" />
+    <PackageVersion Include="OpenTelemetry" Version="1.8.1" />
+    <PackageVersion Include="OpenTelemetry.Exporter.Otlp" Version="1.8.1" />
+    <PackageVersion Include="OpenTelemetry.Exporter.Prometheus.AspNetCore" Version="1.8.1" />
+    <PackageVersion Include="OpenTelemetry.Extensions.Hosting" Version="1.8.1" />
+    <PackageVersion Include="OpenTelemetry.Instrumentation.AspNetCore" Version="1.8.1" />
     <PackageVersion Include="Serilog.AspNetCore" Version="8.0.1" />
     <PackageVersion Include="Serilog.Sinks.Console" Version="5.0.1" />
-    <PackageVersion Include="Microsoft.Extensions.Diagnostics.HealthChecks" Version="8.0.0" />
-    <PackageVersion Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="8.0.10" />
+    <PackageVersion Include="Swashbuckle.AspNetCore" Version="6.5.0" />
+    <PackageVersion Include="System.IdentityModel.Tokens.Jwt" Version="7.2.0" />
+    <PackageVersion Include="xunit" Version="2.6.2" />
+    <PackageVersion Include="xunit.runner.visualstudio" Version="2.5.3" />
   </ItemGroup>
 </Project>

--- a/src/AppHost/Momentum.AppHost.csproj
+++ b/src/AppHost/Momentum.AppHost.csproj
@@ -5,9 +5,9 @@
     <Nullable>enable</Nullable>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Aspire.Hosting" Version="8.0.0-preview.5.23620.2" />
-    <PackageReference Include="Aspire.Hosting.Dapr" Version="8.0.0-preview.5.23620.2" />
-    <PackageReference Include="Aspire.Hosting.Kafka" Version="8.0.0-preview.5.23620.2" />
-    <PackageReference Include="Aspire.Hosting.PostgreSQL" Version="8.0.0-preview.5.23620.2" />
+    <PackageReference Include="Aspire.Hosting" />
+    <PackageReference Include="Aspire.Hosting.Dapr" />
+    <PackageReference Include="Aspire.Hosting.Kafka" />
+    <PackageReference Include="Aspire.Hosting.PostgreSQL" />
   </ItemGroup>
 </Project>

--- a/src/services/identifier/Identifier.Api/Identifier.Api.csproj
+++ b/src/services/identifier/Identifier.Api/Identifier.Api.csproj
@@ -5,12 +5,12 @@
     <ImplicitUsings>enable</ImplicitUsings>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Grpc.AspNetCore" Version="2.57.0" />
-    <PackageReference Include="Dapr.AspNetCore" Version="1.13.0" />
-    <PackageReference Include="Aspire.Microsoft.AspNetCore.Hosting" Version="8.0.0-preview.5.23620.2" />
-    <PackageReference Include="OpenTelemetry.Extensions.Hosting" Version="1.8.1" />
-    <PackageReference Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="8.0.0" />
-    <PackageReference Include="Swashbuckle.AspNetCore" Version="6.5.0" />
+    <PackageReference Include="Grpc.AspNetCore" />
+    <PackageReference Include="Dapr.AspNetCore" />
+    <PackageReference Include="Aspire.Microsoft.AspNetCore.Hosting" />
+    <PackageReference Include="OpenTelemetry.Extensions.Hosting" />
+    <PackageReference Include="Microsoft.AspNetCore.Authentication.JwtBearer" />
+    <PackageReference Include="Swashbuckle.AspNetCore" />
   </ItemGroup>
   <ItemGroup>
     <Protobuf Include="../../../../contracts/identifier/authentication.proto" GrpcServices="Server" Link="Protos/authentication.proto" />

--- a/src/services/identifier/Identifier.Infrastructure/Identifier.Infrastructure.csproj
+++ b/src/services/identifier/Identifier.Infrastructure/Identifier.Infrastructure.csproj
@@ -5,12 +5,12 @@
     <ImplicitUsings>enable</ImplicitUsings>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Dapr.Client" Version="1.13.0" />
-    <PackageReference Include="OpenTelemetry.Extensions.Hosting" Version="1.8.1" />
-    <PackageReference Include="OpenTelemetry.Exporter.Prometheus.AspNetCore" Version="1.8.1" />
-    <PackageReference Include="Microsoft.Extensions.Hosting" Version="8.0.0" />
-    <PackageReference Include="Microsoft.Extensions.Options.ConfigurationExtensions" Version="8.0.0" />
-    <PackageReference Include="System.IdentityModel.Tokens.Jwt" Version="7.2.0" />
+    <PackageReference Include="Dapr.Client" />
+    <PackageReference Include="OpenTelemetry.Extensions.Hosting" />
+    <PackageReference Include="OpenTelemetry.Exporter.Prometheus.AspNetCore" />
+    <PackageReference Include="Microsoft.Extensions.Hosting" />
+    <PackageReference Include="Microsoft.Extensions.Options.ConfigurationExtensions" />
+    <PackageReference Include="System.IdentityModel.Tokens.Jwt" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="../Identifier.Application/Identifier.Application.csproj" />

--- a/src/services/notifier/Notifier.Api/Notifier.Api.csproj
+++ b/src/services/notifier/Notifier.Api/Notifier.Api.csproj
@@ -5,11 +5,11 @@
     <ImplicitUsings>enable</ImplicitUsings>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Dapr.AspNetCore" Version="1.13.0" />
-    <PackageReference Include="Aspire.Microsoft.AspNetCore.Hosting" Version="8.0.0-preview.5.23620.2" />
-    <PackageReference Include="OpenTelemetry.Extensions.Hosting" Version="1.8.1" />
-    <PackageReference Include="Swashbuckle.AspNetCore" Version="6.5.0" />
-    <PackageReference Include="Microsoft.AspNetCore.SignalR.Client" Version="8.0.0" />
+    <PackageReference Include="Dapr.AspNetCore" />
+    <PackageReference Include="Aspire.Microsoft.AspNetCore.Hosting" />
+    <PackageReference Include="OpenTelemetry.Extensions.Hosting" />
+    <PackageReference Include="Swashbuckle.AspNetCore" />
+    <PackageReference Include="Microsoft.AspNetCore.SignalR.Client" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="../Notifier.Application/Notifier.Application.csproj" />

--- a/src/services/notifier/Notifier.Infrastructure/Notifier.Infrastructure.csproj
+++ b/src/services/notifier/Notifier.Infrastructure/Notifier.Infrastructure.csproj
@@ -5,10 +5,10 @@
     <ImplicitUsings>enable</ImplicitUsings>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Dapr.Client" Version="1.13.0" />
-    <PackageReference Include="Confluent.Kafka" Version="2.4.0" />
-    <PackageReference Include="OpenTelemetry.Extensions.Hosting" Version="1.8.1" />
-    <PackageReference Include="Azure.Communication.Email" Version="1.1.0" />
+    <PackageReference Include="Dapr.Client" />
+    <PackageReference Include="Confluent.Kafka" />
+    <PackageReference Include="OpenTelemetry.Extensions.Hosting" />
+    <PackageReference Include="Azure.Communication.Email" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="../Notifier.Application/Notifier.Application.csproj" />

--- a/src/services/streamer/Streamer.Api/Streamer.Api.csproj
+++ b/src/services/streamer/Streamer.Api/Streamer.Api.csproj
@@ -5,11 +5,11 @@
     <ImplicitUsings>enable</ImplicitUsings>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Grpc.AspNetCore" Version="2.57.0" />
-    <PackageReference Include="Dapr.AspNetCore" Version="1.13.0" />
-    <PackageReference Include="Aspire.Microsoft.AspNetCore.Hosting" Version="8.0.0-preview.5.23620.2" />
-    <PackageReference Include="OpenTelemetry.Extensions.Hosting" Version="1.8.1" />
-    <PackageReference Include="Swashbuckle.AspNetCore" Version="6.5.0" />
+    <PackageReference Include="Grpc.AspNetCore" />
+    <PackageReference Include="Dapr.AspNetCore" />
+    <PackageReference Include="Aspire.Microsoft.AspNetCore.Hosting" />
+    <PackageReference Include="OpenTelemetry.Extensions.Hosting" />
+    <PackageReference Include="Swashbuckle.AspNetCore" />
   </ItemGroup>
   <ItemGroup>
     <Protobuf Include="../../../../contracts/streamer/ingestion.proto" GrpcServices="Server" Link="Protos/ingestion.proto" />

--- a/src/services/streamer/Streamer.Infrastructure/Streamer.Infrastructure.csproj
+++ b/src/services/streamer/Streamer.Infrastructure/Streamer.Infrastructure.csproj
@@ -5,11 +5,11 @@
     <ImplicitUsings>enable</ImplicitUsings>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Confluent.Kafka" Version="2.4.0" />
-    <PackageReference Include="Npgsql" Version="8.0.3" />
-    <PackageReference Include="Apache.Ignite" Version="2.16.0" />
-    <PackageReference Include="Dapr.Client" Version="1.13.0" />
-    <PackageReference Include="OpenTelemetry.Extensions.Hosting" Version="1.8.1" />
+    <PackageReference Include="Confluent.Kafka" />
+    <PackageReference Include="Npgsql" />
+    <PackageReference Include="Apache.Ignite" />
+    <PackageReference Include="Dapr.Client" />
+    <PackageReference Include="OpenTelemetry.Extensions.Hosting" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="../Streamer.Application/Streamer.Application.csproj" />

--- a/src/services/web-backend-core/WebBackendCore.Api/WebBackendCore.Api.csproj
+++ b/src/services/web-backend-core/WebBackendCore.Api/WebBackendCore.Api.csproj
@@ -5,12 +5,12 @@
     <ImplicitUsings>enable</ImplicitUsings>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Dapr.AspNetCore" Version="1.13.0" />
-    <PackageReference Include="OpenTelemetry.Extensions.Hosting" Version="1.8.1" />
-    <PackageReference Include="Aspire.Microsoft.AspNetCore.Hosting" Version="8.0.0-preview.5.23620.2" />
-    <PackageReference Include="Swashbuckle.AspNetCore" Version="6.5.0" />
-    <PackageReference Include="OpenFeature" Version="1.8.0" />
-    <PackageReference Include="OpenFeature.Contrib.Providers.Memory" Version="1.2.0" />
+    <PackageReference Include="Dapr.AspNetCore" />
+    <PackageReference Include="OpenTelemetry.Extensions.Hosting" />
+    <PackageReference Include="Aspire.Microsoft.AspNetCore.Hosting" />
+    <PackageReference Include="Swashbuckle.AspNetCore" />
+    <PackageReference Include="OpenFeature" />
+    <PackageReference Include="OpenFeature.Contrib.Providers.Memory" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="../WebBackendCore.Application/WebBackendCore.Application.csproj" />

--- a/src/services/web-backend-core/WebBackendCore.Infrastructure/WebBackendCore.Infrastructure.csproj
+++ b/src/services/web-backend-core/WebBackendCore.Infrastructure/WebBackendCore.Infrastructure.csproj
@@ -5,8 +5,8 @@
     <ImplicitUsings>enable</ImplicitUsings>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Microsoft.AspNetCore.SignalR" Version="1.1.0" />
-    <PackageReference Include="OpenTelemetry.Extensions.Hosting" Version="1.8.1" />
+    <PackageReference Include="Microsoft.AspNetCore.SignalR" />
+    <PackageReference Include="OpenTelemetry.Extensions.Hosting" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="../WebBackendCore.Application/WebBackendCore.Application.csproj" />

--- a/tests/Notifier/Notifier.Api.Integration/Notifier.Api.Integration.csproj
+++ b/tests/Notifier/Notifier.Api.Integration/Notifier.Api.Integration.csproj
@@ -4,9 +4,9 @@
     <IsPackable>false</IsPackable>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" Version="8.0.0" />
-    <PackageReference Include="xunit" Version="2.6.2" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.8.0" />
+    <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" />
+    <PackageReference Include="xunit" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="../../../src/services/notifier/Notifier.Api/Notifier.Api.csproj" />

--- a/tests/Streamer/Streamer.Application.Tests/Streamer.Application.Tests.csproj
+++ b/tests/Streamer/Streamer.Application.Tests/Streamer.Application.Tests.csproj
@@ -4,10 +4,10 @@
     <IsPackable>false</IsPackable>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="xunit" Version="2.6.2" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.3" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.8.0" />
-    <PackageReference Include="Moq" Version="4.20.69" />
+    <PackageReference Include="xunit" />
+    <PackageReference Include="xunit.runner.visualstudio" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" />
+    <PackageReference Include="Moq" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="../../../src/services/streamer/Streamer.Application/Streamer.Application.csproj" />


### PR DESCRIPTION
## Summary
- add missing PackageVersion entries for packages used across the solution
- remove inline version attributes from project files to rely on central package management

## Testing
- not run (dotnet CLI not available in container)


------
https://chatgpt.com/codex/tasks/task_e_68e975473e048333bd50b069ea1437b1
- Fixes #54 (commit fa6aced)