### PR TITLE
Add release notes for version 0.0.1

### DIFF
--- a/ReleaseNotes/0.0.1.md
+++ b/ReleaseNotes/0.0.1.md
@@ -1,0 +1,35 @@
+# Release 0.0.1
+
+La prima anteprima pubblica della piattaforma Momentum. Questa build consolida lo scheletro
+monorepo e mette a disposizione gli elementi fondamentali per avviare l'infrastruttura
+end-to-end in ambienti di sviluppo.
+
+## Highlights
+- Monolite modulare .NET Aspire con orchestrazione di Dapr e Kafka pronta all'uso.
+- Frontend Angular 19 standalone con module federation e pipeline i18n attive.
+- Stack dati composto da TimescaleDB e Apache Ignite integrati con il flusso di telemetria.
+- Observability basata su OpenTelemetry con esport verso Prometheus, Loki, Tempo e Grafana.
+- Workflow CI che esegue build, test e controlli di sicurezza su ogni modifica.
+
+## Servizi inclusi
+- **identifier** per autenticazione e gestione licenze.
+- **streamer** per ingest telemetria e sincronizzazione cache.
+- **notifier** per dispatch multi-canale e integrazione SignalR.
+- **web-backend-core** come gateway API e hub realtime.
+- **web-core** come frontend modulare.
+
+## Tooling e automazioni
+- Dev Container pronto con make targets per build, test e security scan.
+- Script per generare dati di esempio e pacchetti dei contratti pubblici.
+- Automazione per forzare il linking alle issue in ogni commit.
+- Script di generazione release notes per repository e moduli.
+
+## Known issues
+- Le pipeline di release richiedono ancora accesso manuale al repository remoto.
+- Il flusso di dati realtime è validato solo in ambiente di sviluppo locale.
+- Mancano ancora test end-to-end automatizzati tra frontend e servizi backend.
+
+## Prossimi passi
+- Pubblicazione di immagini Docker e template di deployment.
+- Copertura test ampliata per i servizi principali.
+- Documentazione di dettaglio per ogni modulo applicativo.


### PR DESCRIPTION
## Summary
- add the initial ReleaseNotes/0.0.1.md file to document the first public preview
- highlight the included services, tooling automation, known issues, and next steps for the 0.0.1 release

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e980b81de88333bb597a2fe4b9b02a
- Fixes #60 (commit a53ff43)