### PR TITLE
Add VS Code configuration for launching solution

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,0 +1,31 @@
+{
+  "$schema": "https://json.schemastore.org/launch", 
+  "version": "0.2.0",
+  "configurations": [
+    {
+      "name": "Momentum AppHost",
+      "type": "coreclr",
+      "request": "launch",
+      "preLaunchTask": "build Momentum AppHost",
+      "project": "${workspaceFolder}/src/AppHost/Momentum.AppHost.csproj",
+      "cwd": "${workspaceFolder}/src/AppHost"
+    },
+    {
+      "name": "Momentum web-core (Chrome)",
+      "type": "pwa-chrome",
+      "request": "launch",
+      "url": "http://localhost:4200",
+      "webRoot": "${workspaceFolder}/src/web-core",
+      "preLaunchTask": "Start Angular web-core"
+    }
+  ],
+  "compounds": [
+    {
+      "name": "Momentum full stack",
+      "configurations": [
+        "Momentum AppHost",
+        "Momentum web-core (Chrome)"
+      ]
+    }
+  ]
+}

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -1,0 +1,55 @@
+{
+  "version": "2.0.0",
+  "tasks": [
+    {
+      "label": "restore Momentum solution",
+      "type": "process",
+      "command": "dotnet",
+      "args": [
+        "restore",
+        "Momentum.sln"
+      ],
+      "problemMatcher": "$msCompile"
+    },
+    {
+      "label": "build Momentum AppHost",
+      "type": "process",
+      "command": "dotnet",
+      "args": [
+        "build",
+        "src/AppHost/Momentum.AppHost.csproj"
+      ],
+      "group": {
+        "kind": "build",
+        "isDefault": true
+      },
+      "problemMatcher": "$msCompile"
+    },
+    {
+      "label": "Start Angular web-core",
+      "type": "shell",
+      "command": "npm",
+      "args": [
+        "run",
+        "start",
+        "--prefix",
+        "src/web-core"
+      ],
+      "isBackground": true,
+      "problemMatcher": {
+        "owner": "angular",
+        "pattern": {
+          "regexp": ".",
+          "file": 0,
+          "location": 0,
+          "message": 0
+        },
+        "background": {
+          "activeOnStart": true,
+          "beginsPattern": ".*",
+          "endsPattern": ".*Compiled successfully.*"
+        }
+      }
+    }
+  ]
+}


### PR DESCRIPTION
## Summary
- add VS Code tasks to restore the solution, build the AppHost, and launch the Angular frontend
- add launch configurations for debugging the AppHost and opening the frontend with a Chrome instance, including a compound full-stack profile

## Testing
- dotnet build src/AppHost/Momentum.AppHost.csproj *(fails: command not found: dotnet)*

------
https://chatgpt.com/codex/tasks/task_e_68eb54e68ba48333a0addf2c8548726c
- Closes #77 (commit 9fffc86)