### PR TITLE
docs: align bilingual documentation across repository

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,78 +1,146 @@
-# Momentum Platform
+# Momentum Platform / Piattaforma Momentum
 
-Momentum è una piattaforma modulare e resiliente progettata per essere eseguita come monolite modulare oppure evolvere in una topologia a microservizi senza cambiare i contratti pubblici.
+## Overview / Panoramica
+**English:** Momentum is a modular and resilient platform that can run as a modular monolith or evolve into a microservice topology without changing public contracts.
+
+**Italiano:** Momentum è una piattaforma modulare e resiliente che può funzionare come monolite modulare oppure evolvere in una topologia a microservizi senza modificare i contratti pubblici.
 
 ## Stack
+**English:**
+- **Backend:** .NET 8 Aspire with Dapr over gRPC and Kafka pub/sub.
+- **Frontend:** Angular 19 (standalone, i18n, module federation ready).
+- **Data:** TimescaleDB for historical storage, Apache Ignite for caching.
+- **Messaging:** Kafka for telemetry events.
+- **Realtime:** SignalR and notification channels.
+- **Observability:** OpenTelemetry exported to Prometheus, Loki, Tempo, Grafana.
+- **Security:** JWT with OpenFeature-ready hooks.
+- **Licensing:** OSS-only dependencies (Docker images `-oss`/Debian and community libraries).
 
-- **Backend**: .NET 8 Aspire + Dapr gRPC e pub/sub Kafka
-- **Frontend**: Angular 19 standalone, i18n, module federation
-- **Dati**: TimescaleDB per storico, Apache Ignite per cache
-- **Messaging**: Kafka per eventi telemetrici
-- **Realtime**: SignalR e canali notifiche
-- **Observability**: OpenTelemetry → Prometheus, Loki, Tempo, Grafana
-- **Sicurezza**: JWT, OpenFeature-ready
-- **Licensing**: Solo componenti OSS (immagini Docker `-oss`/Debian e librerie community)
+**Italiano:**
+- **Backend:** .NET 8 Aspire con Dapr su gRPC e pub/sub Kafka.
+- **Frontend:** Angular 19 (standalone, i18n, predisposto per module federation).
+- **Dati:** TimescaleDB per lo storico, Apache Ignite per la cache.
+- **Messaging:** Kafka per gli eventi telemetrici.
+- **Realtime:** SignalR e canali di notifica.
+- **Osservabilità:** OpenTelemetry esportato verso Prometheus, Loki, Tempo, Grafana.
+- **Sicurezza:** JWT con integrazione OpenFeature-ready.
+- **Licensing:** Dipendenze solo OSS (immagini Docker `-oss`/Debian e librerie community).
 
-## Quick start
-
+## Quick start / Avvio rapido
+**English:**
 ```bash
 make build
 make dev
 ```
+Orchestrate the full topology with Aspire:
+```bash
+dotnet run --project src/AppHost/Momentum.AppHost.csproj
+```
 
-Oppure con Aspire:
-
+**Italiano:**
+```bash
+make build
+make dev
+```
+Per orchestrare l'intera topologia con Aspire:
 ```bash
 dotnet run --project src/AppHost/Momentum.AppHost.csproj
 ```
 
 ## Devcontainer
+**English:** The repository ships a ready-to-use [Dev Container](https://containers.dev/) configuration in `.devcontainer/`. It ensures a consistent environment for builds, tests, and security checks. Follow the detailed instructions in [`docs/devcontainer.md`](docs/devcontainer.md).
 
-Il repository include una configurazione [Dev Container](https://containers.dev/) pronta all'uso nella cartella `.devcontainer/`. Consente di avere un ambiente di sviluppo coerente per build, test e controlli di sicurezza.
+**Italiano:** Il repository include una configurazione [Dev Container](https://containers.dev/) pronta all'uso in `.devcontainer/`. Garantisce un ambiente coerente per build, test e controlli di sicurezza. Le istruzioni dettagliate sono in [`docs/devcontainer.md`](docs/devcontainer.md).
 
-1. Apri la cartella del progetto con VS Code e scegli `Reopen in Container`.
-2. Al termine del provisioning verranno ripristinati automaticamente i pacchetti .NET e Angular.
-3. Sono già disponibili i task `Build (make)`, `Test (make)` e `Security scan` per eseguire rapidamente build, test e audit dipendenze.
-4. Le porte principali (4200, 5000, 5001, 9090) vengono esposte automaticamente verso l'host.
+## Services / Servizi
+**English:**
+| Service | Description |
+| --- | --- |
+| identifier | Authentication and license management |
+| streamer | Telemetry ingestion from Kafka → Timescale/Ignite |
+| notifier | Multi-channel notification dispatch |
+| web-backend-core | API gateway + SignalR hub |
+| web-core | Modular Angular frontend |
 
-## Servizi
-
+**Italiano:**
 | Servizio | Descrizione |
 | --- | --- |
 | identifier | Autenticazione e gestione licenze |
-| streamer | Ingest telemetria da Kafka → Timescale/ Ignite |
-| notifier | Dispatch notifiche multi-canale |
-| web-backend-core | Gateway API + SignalR hub |
+| streamer | Ingest telemetria da Kafka → Timescale/Ignite |
+| notifier | Invio notifiche multi-canale |
+| web-backend-core | Gateway API + hub SignalR |
 | web-core | Frontend modulare Angular |
 
-## Flusso end-to-end
+## End-to-end flow / Flusso end-to-end
+**English:**
+1. A raw event arrives on `telemetry.input` (Kafka).
+2. The streamer transforms it, persists to Timescale, invalidates Ignite cache, and publishes `telemetry.ingested`.
+3. The notifier subscribes to the event, delivers mail/SignalR via web-backend-core.
+4. Web-backend-core broadcasts on the SignalR hub.
+5. Web-core receives the realtime notification and updates the dashboard.
 
-1. Evento grezzo su `telemetry.input` (Kafka)
-2. Streamer lo trasforma e persiste su Timescale, invalida cache Ignite e pubblica `telemetry.ingested`
-3. Notifier sottoscrive l'evento, invia mail/SignalR verso web-backend-core
-4. Web-backend-core broadcast su hub SignalR
-5. Web-core riceve notifica realtime e la mostra nella dashboard
+**Italiano:**
+1. Un evento grezzo arriva su `telemetry.input` (Kafka).
+2. Lo streamer lo trasforma, lo persiste su Timescale, invalida la cache Ignite e pubblica `telemetry.ingested`.
+3. Il notifier sottoscrive l'evento, invia mail/SignalR tramite web-backend-core.
+4. Web-backend-core trasmette sull'hub SignalR.
+5. Web-core riceve la notifica realtime e aggiorna la dashboard.
 
-## Scripts utili
+## Useful scripts / Script utili
+**English:**
+- `tools/scripts/generate-sample-data.sh` seeds demo events.
+- `make test` runs .NET and Angular tests (best-effort in CI).
+- `make contracts` produces the contract bundle.
 
-- `tools/scripts/generate-sample-data.sh` genera eventi demo
-- `make test` esegue test .NET e Angular (best-effort in CI
-)
-- `make contracts` produce archivio dei contratti
+**Italiano:**
+- `tools/scripts/generate-sample-data.sh` genera eventi demo.
+- `make test` esegue test .NET e Angular (best-effort in CI).
+- `make contracts` produce l'archivio dei contratti.
 
-## Deploy
+## Deployment / Deploy
+**English:**
+- `docker compose up` spins up the full environment (infrastructure + services).
+- `src/AppHost` hosts local orchestration with .NET Aspire.
 
-- `docker compose up` per ambiente completo (infra + servizi)
-- `src/AppHost` per orchestrazione locale con .NET Aspire
+**Italiano:**
+- `docker compose up` avvia l'ambiente completo (infra + servizi).
+- `src/AppHost` gestisce l'orchestrazione locale con .NET Aspire.
 
-## Documentazione
+## Repository configuration / Configurazione del repository
+**English:**
+- `Directory.Build.props` centralises common .NET build settings (nullable, analyzers, warnings-as-errors).
+- `Directory.Packages.props` manages package versions and floating constraints shared across projects.
+- `NuGet.config` pins internal feeds and enables repeatable restore.
+- `global.json` locks the .NET SDK version used by CI and devcontainer.
+- `Makefile` orchestrates build, test, lint, contracts, and release automation.
+- `docker-compose*.yml` files define local/CI infrastructure for databases, Kafka, and observability.
+- `ReleaseNotes/` collects generated release artefacts per version.
 
-- [Architecture Overview](architecture-overview.md)
-- Cartella `docs/` per policy e ADR
-- Cartella `contracts/` per proto/OpenAPI/event schema
+**Italiano:**
+- `Directory.Build.props` centralizza le impostazioni comuni di build .NET (nullable, analyzer, warnings-as-errors).
+- `Directory.Packages.props` gestisce le versioni dei pacchetti e i vincoli condivisi fra i progetti.
+- `NuGet.config` blocca i feed interni e abilita restore ripetibili.
+- `global.json` vincola la versione di .NET SDK usata da CI e devcontainer.
+- `Makefile` coordina build, test, lint, contratti e automazioni di release.
+- I file `docker-compose*.yml` definiscono l'infrastruttura locale/CI per database, Kafka e osservabilità.
+- `ReleaseNotes/` raccoglie gli artefatti di release generati per versione.
 
-## Automazioni di processo
+## Documentation / Documentazione
+**English:**
+- [`architecture-overview.md`](architecture-overview.md) describes the system using the C4 model.
+- [`docs/`](docs/) contains policies, guidelines, ADRs, and operational manuals.
+- [`contracts/`](contracts/) holds proto/OpenAPI/event schemas.
 
-- **Ensure issue linking**: workflow che garantisce che ogni commit sia collegato a una issue. In assenza del riferimento genera automaticamente un ticket riassumendo le modifiche e aggiorna la descrizione della pull request.
-- **Generate release notes**: workflow manuale che produce i file di release note per repository e moduli, collocandoli nelle cartelle `ReleaseNotes/` con il numero di versione fornito.
+**Italiano:**
+- [`architecture-overview.md`](architecture-overview.md) descrive il sistema con il modello C4.
+- [`docs/`](docs/) ospita policy, linee guida, ADR e manuali operativi.
+- [`contracts/`](contracts/) contiene i contratti proto/OpenAPI/eventi.
 
+## Process automation / Automazioni di processo
+**English:**
+- **Ensure issue linking:** workflow that enforces issue references in commits. When missing, it opens a summary ticket and updates the pull request description.
+- **Generate release notes:** manual workflow that creates release note files for the repository and modules, stored under `ReleaseNotes/` with the provided version number.
+
+**Italiano:**
+- **Ensure issue linking:** workflow che impone la presenza del riferimento alle issue nei commit. In mancanza, apre un ticket riassuntivo e aggiorna la descrizione della pull request.
+- **Generate release notes:** workflow manuale che crea i file di release note per repository e moduli, salvati in `ReleaseNotes/` con il numero di versione fornito.

--- a/architecture-overview.md
+++ b/architecture-overview.md
@@ -1,37 +1,68 @@
-# Architecture Overview (C4)
+# Architecture Overview (C4) / Panoramica Architetturale (C4)
 
-## C1 – System Context
+## C1 – System Context / Contesto di Sistema
+**English:**
+- **Momentum Platform** ingests telemetry, manages identities, and broadcasts notifications.
+- External actors: Operators (web UI), sensor producers (Kafka), email/SMS providers, observability stack.
 
-- **Momentum Platform** for ingesting telemetry, managing identities and broadcasting notifications.
-- External Actors: Operators (web UI), Sensor producers (Kafka), Email/SMS providers, Observability stack.
+**Italiano:**
+- **Momentum Platform** raccoglie telemetria, gestisce identità e pubblica notifiche.
+- Attori esterni: Operatori (web UI), produttori di sensori (Kafka), provider email/SMS, stack di osservabilità.
 
-## C2 – Container Diagram
+## C2 – Container Diagram / Diagramma dei Container
+**English:**
+- **web-core (Angular):** shell consuming SignalR and federated modules.
+- **web-backend-core (.NET):** API gateway + SignalR hub + OpenFeature integration.
+- **identifier service:** gRPC auth, JWT minting.
+- **streamer service:** Kafka consumer, TimescaleDB persistence, Ignite cache.
+- **notifier service:** Subscribes to `telemetry.ingested`, dispatches email/SignalR.
+- **Infrastructure:** Kafka, TimescaleDB, Ignite, Prometheus, Loki, Tempo, Grafana, Dapr sidecars.
 
-- **web-core (Angular)**: shell, consumes SignalR, federated modules
-- **web-backend-core (.NET)**: API gateway + SignalR hub + OpenFeature integration
-- **identifier service**: gRPC auth, JWT minting
-- **streamer service**: Kafka consumer, TimescaleDB persistence, Ignite cache
-- **notifier service**: Subscribes to `telemetry.ingested`, dispatches email/SignalR
-- **Infrastructure**: Kafka, TimescaleDB, Ignite, Prometheus, Loki, Tempo, Grafana, Dapr sidecars
+**Italiano:**
+- **web-core (Angular):** shell che consuma SignalR e moduli federati.
+- **web-backend-core (.NET):** API gateway + hub SignalR + integrazione OpenFeature.
+- **identifier service:** autenticazione gRPC, emissione JWT.
+- **streamer service:** consumer Kafka, persistenza TimescaleDB, cache Ignite.
+- **notifier service:** si sottoscrive a `telemetry.ingested`, inoltra email/SignalR.
+- **Infrastruttura:** Kafka, TimescaleDB, Ignite, Prometheus, Loki, Tempo, Grafana, sidecar Dapr.
 
-## C3 – Component Diagram (web-backend-core)
+## C3 – Component Diagram (web-backend-core) / Diagramma dei Componenti (web-backend-core)
+**English:**
+- Controllers orchestrate requests.
+- `NotificationOrchestrator` coordinates broadcasts.
+- `SignalRNotificationBroadcaster` publishes to the hub.
+- `NotificationHub` exposes the realtime channel.
+- `DaprClient` handles module invocations.
 
-- **Controllers** orchestrate requests
-- **NotificationOrchestrator** coordinates broadcast
-- **SignalRNotificationBroadcaster** publishes to hub
-- **NotificationHub** exposes realtime channel
-- **Dapr Client** handles module invocations
+**Italiano:**
+- I controller orchestrano le richieste.
+- `NotificationOrchestrator` coordina i broadcast.
+- `SignalRNotificationBroadcaster` pubblica sull'hub.
+- `NotificationHub` espone il canale realtime.
+- `DaprClient` gestisce le invocazioni ai moduli.
 
-## C4 – Code/Module View
+## C4 – Code/Module View / Vista Code/Modulo
+**English:**
+- Clean architecture layers per service (`Domain` → `Application` → `Infrastructure` → `Api`).
+- Versioned contracts in `/contracts`.
+- Tests in `/tests`.
+- Module federation powering the modular frontend.
 
-- Clean architecture layers per servizio (`Domain` → `Application` → `Infrastructure` → `Api`)
-- Contracts versionati in `/contracts`
-- Tests in `/tests`
-- Module federation per front-end modulare
+**Italiano:**
+- Strati clean architecture per servizio (`Domain` → `Application` → `Infrastructure` → `Api`).
+- Contratti versionati in `/contracts`.
+- Test in `/tests`.
+- Module federation a supporto del frontend modulare.
 
-## Quality Attributes
+## Quality Attributes / Attributi di Qualità
+**English:**
+- **Resilience:** Dapr retries, Kafka buffering, Ignite caching.
+- **Observability:** OpenTelemetry/Prometheus, logs in Loki, traces in Tempo.
+- **Security:** JWT, roles, feature flags via OpenFeature.
+- **Evolvability:** Stable contracts, bounded contexts per module, plug-in modules.
 
-- **Resilienza**: Dapr retries, Kafka buffering, Ignite caching
-- **Osservabilità**: OpenTelemetry/Prometheus, logs su Loki, traces su Tempo
-- **Sicurezza**: JWT, ruoli, feature flag via OpenFeature
-- **Evolvibilità**: Contratti stabili, bounded context per modulo, moduli plug-in
+**Italiano:**
+- **Resilienza:** retry Dapr, buffering Kafka, caching Ignite.
+- **Osservabilità:** OpenTelemetry/Prometheus, log su Loki, trace su Tempo.
+- **Sicurezza:** JWT, ruoli, feature flag con OpenFeature.
+- **Evolvibilità:** Contratti stabili, bounded context per modulo, moduli plug-in.

--- a/docs/01-Architecture
+++ b/docs/01-Architecture
@@ -1,0 +1,7 @@
+# Architecture Index / Indice Architetturale
+
+## English
+Refer to [`../01-Architecture-Policy.md`](../01-Architecture-Policy.md) and [`../../architecture-overview.md`](../../architecture-overview.md) for the C4 model and architectural principles.
+
+## Italiano
+Consulta [`../01-Architecture-Policy.md`](../01-Architecture-Policy.md) e [`../../architecture-overview.md`](../../architecture-overview.md) per il modello C4 e i principi architetturali.

--- a/docs/01-Architecture-Policy.md
+++ b/docs/01-Architecture-Policy.md
@@ -1,6 +1,14 @@
-# Architecture Policy
+# Architecture Policy / Politica Architetturale
 
-- Ogni bounded context rispetta DDD + Clean Architecture.
-- I contratti esterni (gRPC, OpenAPI, event schema) sono versionati in `/contracts` e pubblicati come artefatti CI.
-- Aspire e Dapr sono il default per orchestrazione locale e service invocation.
-- Le dipendenze infra (Kafka, Timescale, Ignite) sono gestite tramite IaC (docker compose / Bicep TBD).
+## Principles / Principi
+**English:**
+- Each bounded context follows DDD with Clean Architecture layering.
+- External contracts (gRPC, OpenAPI, event schema) live in `/contracts` and are published as CI artefacts.
+- Aspire and Dapr are the default for local orchestration and service invocation.
+- Infrastructure dependencies (Kafka, Timescale, Ignite) are managed as code (docker compose / Bicep TBD).
+
+**Italiano:**
+- Ogni bounded context segue DDD con layering Clean Architecture.
+- I contratti esterni (gRPC, OpenAPI, event schema) risiedono in `/contracts` e vengono pubblicati come artefatti CI.
+- Aspire e Dapr sono il default per l'orchestrazione locale e le chiamate fra servizi.
+- Le dipendenze infrastrutturali (Kafka, Timescale, Ignite) sono gestite come codice (docker compose / Bicep da definire).

--- a/docs/02-Coding-Guidelines.md
+++ b/docs/02-Coding-Guidelines.md
@@ -1,17 +1,27 @@
-# Coding Guidelines
+# Coding Guidelines / Linee Guida di Sviluppo
 
-- C# 12, `net8.0`, nullable abilitato.
-- Layering: `Api` dipende da `Application` → `Domain`, `Infrastructure` implementa porte.
-- Validazione input tramite record e handler CQRS light.
-- Frontend Angular standalone components, SignalR typed wrappers, RxJS per stream.
-- Ogni feature richiede test unitari + integrazione minimi.
+## Core practices / Pratiche di base
+**English:**
+- Target C# 12 on `net8.0` with nullable enabled.
+- Layering: `Api` depends on `Application` → `Domain`; `Infrastructure` implements ports.
+- Input validation relies on records and light CQRS handlers.
+- Frontend uses Angular standalone components, typed SignalR wrappers, and RxJS streams.
+- Every feature requires unit tests plus minimal integration coverage.
 
-## Commit & Issue hygiene
+**Italiano:**
+- Target C# 12 su `net8.0` con nullable abilitato.
+- Layering: `Api` dipende da `Application` → `Domain`; `Infrastructure` implementa le porte.
+- La validazione input utilizza record e handler CQRS leggeri.
+- Il frontend adotta componenti standalone Angular, wrapper SignalR tipizzati e stream RxJS.
+- Ogni feature richiede test unitari più una copertura di integrazione minima.
 
-- Ogni commit deve riportare nel subject il riferimento alla issue principale (`#123`) che lo ha
-  originato.
-- Le pull request devono mantenere la sezione _Fixes_ aggiornata con tutte le issue coperte. Il
-  workflow _Ensure issue linking_ aggiorna automaticamente la descrizione quando rileva commit non
-  collegati e crea eventuali issue mancanti tramite LLM.
-- Prima del merge assicurarsi che i commit siano ripuliti e squashed solo se strettamente
-  necessario, mantenendo la tracciabilità con le issue generate.
+## Commit & issue hygiene / Buone pratiche per commit e issue
+**English:**
+- Each commit subject must reference the primary issue (`#123`).
+- Pull requests must keep the _Fixes_ section updated with covered issues. The _Ensure issue linking_ workflow updates the description when it detects unlinked commits and creates missing issues via LLM.
+- Before merging, tidy commits and squash only when necessary to preserve traceability with generated issues.
+
+**Italiano:**
+- Ogni commit deve riportare nel subject il riferimento alla issue principale (`#123`).
+- Le pull request devono mantenere aggiornata la sezione _Fixes_ con le issue coperte. Il workflow _Ensure issue linking_ aggiorna la descrizione quando rileva commit non collegati e crea le issue mancanti tramite LLM.
+- Prima del merge ripulisci i commit e fai squash solo se necessario, preservando la tracciabilità con le issue generate.

--- a/docs/03-Versioning-Policy.md
+++ b/docs/03-Versioning-Policy.md
@@ -1,43 +1,51 @@
-# Versioning Policy
+# Versioning Policy / Politica di Versionamento
 
-- Semantic Versioning per servizi e front-end.
-- Contratti gRPC/OpenAPI versionati via namespace/route `vX`.
-- Event schema versionati tramite `$id` incrementale.
-- Tag Docker `major.minor.patch` + `latest` per ambienti demo.
+## SemVer rules / Regole SemVer
+**English:**
+- Services and frontend follow Semantic Versioning.
+- gRPC/OpenAPI contracts versioned through `vX` namespaces/routes.
+- Event schemas carry incremental `$id` identifiers.
+- Docker tags use `major.minor.patch` plus `latest` for demo environments.
 
-## Flusso di merge verso `main`
+**Italiano:**
+- Servizi e frontend adottano il Semantic Versioning.
+- I contratti gRPC/OpenAPI sono versionati tramite namespace/route `vX`.
+- Gli event schema includono identificativi `$id` incrementali.
+- I tag Docker usano `major.minor.patch` e `latest` per gli ambienti demo.
 
-1. Ogni attività viene sviluppata su un branch feature derivato da `main` e collegato ad una
-   issue di GitHub.
-2. I branch feature vengono integrati tramite pull request. Il merge verso `main` avviene
-   esclusivamente con merge commit generati dall'interfaccia GitHub dopo che la pull request è
-   stata approvata e che tutti i controlli automatizzati sono passati.
-3. Prima del merge viene eseguito il workflow _Ensure issue linking_ che verifica che tutti i
-   commit referenzino almeno una issue (`#<numero>`). In assenza del riferimento, lo script
-   genera automaticamente una issue con il riassunto delle modifiche e aggiorna la descrizione
-   della pull request.
-4. Una volta completato il merge, `main` rappresenta sempre lo stato pronto alla release. Il
-   numero di versione viene incrementato e taggato contestualmente alla generazione delle release
-   notes.
+## Merge flow to `main` / Flusso di merge verso `main`
+**English:**
+1. Each task lives on a feature branch derived from `main` and linked to a GitHub issue.
+2. Feature branches merge through pull requests; merging into `main` happens via GitHub merge commits once approvals and checks pass.
+3. Before merging, the _Ensure issue linking_ workflow verifies that every commit references an issue (`#<number>`). If missing, it creates an issue summarising the changes and updates the PR description.
+4. After merge, `main` always reflects a release-ready state. Version numbers are bumped and tagged alongside release note generation.
 
-## Gestione automatica delle issue e dei commit
+**Italiano:**
+1. Ogni attività vive su un branch feature derivato da `main` e collegato a una issue GitHub.
+2. I branch feature vengono integrati tramite pull request; il merge su `main` avviene con merge commit di GitHub dopo approvazioni e controlli positivi.
+3. Prima del merge il workflow _Ensure issue linking_ verifica che ogni commit referenzi una issue (`#<numero>`). Se manca, crea una issue con il riassunto delle modifiche e aggiorna la descrizione della PR.
+4. Dopo il merge `main` rappresenta sempre uno stato pronto alla release. Il numero di versione viene incrementato e taggato insieme alla generazione delle release note.
 
-- Tutti i commit devono includere nel messaggio il riferimento a una issue (`#123`).
-- Lo script `tools/issue_management/ensure_issue_links.py` è invocato nella pipeline di pull
-  request per controllare la presenza del riferimento. Se non è presente, e sono configurate le
-  chiavi `GITHUB_TOKEN` e `OPENAI_API_KEY`, lo script crea automaticamente una nuova issue
-  sintetizzando il contenuto del commit tramite LLM e aggiorna il corpo della pull request con il
-  riferimento `Fixes #<numero>`.
-- L'output dello script indica sempre le azioni svolte e rende il controllo bloccante finché il
-  commit non è correttamente collegato.
+## Automated issue & commit management / Gestione automatica di issue e commit
+**English:**
+- Every commit message must include an issue reference (`#123`).
+- The script `tools/issue_management/ensure_issue_links.py` runs in PR pipelines to enforce references. With `GITHUB_TOKEN` and `OPENAI_API_KEY` configured, it can create missing issues via LLM and update the PR body with `Fixes #<number>`.
+- The script output reports the performed actions and blocks the check until every commit is linked.
+
+**Italiano:**
+- Ogni commit deve includere nel messaggio il riferimento a una issue (`#123`).
+- Lo script `tools/issue_management/ensure_issue_links.py` gira nelle pipeline delle PR per garantire la presenza dei riferimenti. Con `GITHUB_TOKEN` e `OPENAI_API_KEY` configurati crea le issue mancanti via LLM e aggiorna il corpo della PR con `Fixes #<numero>`.
+- L'output dello script riporta le azioni svolte e rende il controllo bloccante finché tutti i commit non sono collegati.
 
 ## Release notes
+**English:**
+- The manual _Generate release notes_ workflow builds release files from commits between a base ref and the target version.
+- Files land in `ReleaseNotes/` and `modules/<module-name>/ReleaseNotes/` for each affected module.
+- Each file lists linked issues and included commits to provide full visibility.
+- During the workflow execution, a commit on `main` is created with the generated notes using the message `chore: add release notes for <version>`.
 
-- Il workflow manuale _Generate release notes_ crea i file di release note a partire dai commit
-  tra un riferimento di base (`base_ref`) e la versione da rilasciare.
-- I file sono posizionati nella cartella `ReleaseNotes/` del repository e nella cartella
-  `modules/<nome-modulo>/ReleaseNotes/` per ciascun modulo toccato dai commit.
-- Ogni file include l'elenco delle issue collegate e dei commit inclusi nella release, così da
-  fornire visibilità completa sulle modifiche.
-- Durante l'esecuzione del workflow viene creato automaticamente un commit su `main` con i file di
-  release note generati e il messaggio `chore: add release notes for <version>`.
+**Italiano:**
+- Il workflow manuale _Generate release notes_ crea i file a partire dai commit tra un riferimento di base e la versione da rilasciare.
+- I file vengono salvati in `ReleaseNotes/` e in `modules/<nome-modulo>/ReleaseNotes/` per ogni modulo interessato.
+- Ogni file elenca le issue collegate e i commit inclusi per offrire piena visibilità.
+- Durante l'esecuzione del workflow viene creato un commit su `main` con le note generate e il messaggio `chore: add release notes for <version>`.

--- a/docs/04-Security-Policy.md
+++ b/docs/04-Security-Policy.md
@@ -1,7 +1,16 @@
-# Security Policy
+# Security Policy / Politica di Sicurezza
 
-- JWT signed con chiave rotabile, memorizzata in Key Vault (placeholder).
-- OpenFeature usato per feature flag/licenze (provider Dapr binding).
-- Minimo privilegio per accesso Timescale/Ignite.
-- gRPC + HTTPS obbligatori in ambienti produttivi.
-- Secret in repo vietati; usare variabili CI/CD.
+## Controls / Controlli
+**English:**
+- JWT tokens are signed with a rotatable key stored in Key Vault (placeholder implementation).
+- OpenFeature drives feature flags and licensing via a Dapr binding provider.
+- Timescale and Ignite access follows the principle of least privilege.
+- gRPC plus HTTPS are mandatory in production environments.
+- Secrets must never live in the repository; use CI/CD variables instead.
+
+**Italiano:**
+- I token JWT sono firmati con una chiave rotabile memorizzata in Key Vault (implementazione placeholder).
+- OpenFeature gestisce feature flag e licensing tramite un provider Dapr binding.
+- L'accesso a Timescale e Ignite segue il principio del minimo privilegio.
+- gRPC e HTTPS sono obbligatori negli ambienti produttivi.
+- I secret non devono mai essere nel repository; usa variabili di CI/CD.

--- a/docs/05-Testing-Policy.md
+++ b/docs/05-Testing-Policy.md
@@ -1,7 +1,16 @@
-# Testing Policy
+# Testing Policy / Politica di Test
 
-- **Unit**: xUnit per .NET, Jasmine per Angular.
-- **Integration**: test gRPC/HTTP con Testcontainers (TODO) e Playwright e2e.
-- **Contract**: verfica schema via `buf`/`spectral` (pipeline step TBD).
-- **E2E**: Playwright orchestrato contro docker compose profile.
-- Copertura minima 70% per domini critici.
+## Coverage pillars / Pilastri di copertura
+**English:**
+- **Unit:** xUnit for .NET, Jasmine for Angular.
+- **Integration:** gRPC/HTTP tests with Testcontainers (TODO) plus Playwright e2e.
+- **Contract:** schema verification via `buf`/`spectral` (pipeline step TBD).
+- **E2E:** Playwright orchestrated against the docker compose profile.
+- **Coverage goal:** minimum 70% for critical domains.
+
+**Italiano:**
+- **Unit:** xUnit per .NET, Jasmine per Angular.
+- **Integration:** test gRPC/HTTP con Testcontainers (TODO) e Playwright e2e.
+- **Contract:** verifica schema tramite `buf`/`spectral` (step di pipeline da definire).
+- **E2E:** Playwright orchestrato contro il profilo docker compose.
+- **Obiettivo copertura:** minimo 70% per i domini critici.

--- a/docs/06-Modular-Architecture-Guidelines.md
+++ b/docs/06-Modular-Architecture-Guidelines.md
@@ -1,6 +1,14 @@
-# Modular Architecture Guidelines
+# Modular Architecture Guidelines / Linee Guida per l'Architettura Modulare
 
-- Ogni modulo espone contratti indipendenti (`/contracts/<module>`).
-- Use-case condivisi passano tramite orchestratore web-backend-core via Dapr gRPC.
-- Module federation: ogni micro-frontend espone entry come remote.
-- Plug-in backend registrati via Dapr service discovery.
+## Contracts & boundaries / Contratti e confini
+**English:**
+- Each module exposes independent contracts in `/contracts/<module>`.
+- Shared use cases flow through the web-backend-core orchestrator via Dapr gRPC.
+- Module federation lets every micro-frontend expose its entry point as a remote.
+- Backend plug-ins register through Dapr service discovery.
+
+**Italiano:**
+- Ogni modulo espone contratti indipendenti in `/contracts/<module>`.
+- I casi d'uso condivisi passano dall'orchestratore web-backend-core tramite gRPC Dapr.
+- La module federation consente a ogni micro-frontend di esporre il proprio entry point come remote.
+- I plug-in backend si registrano tramite il service discovery di Dapr.

--- a/docs/07-Observability-Guidelines.md
+++ b/docs/07-Observability-Guidelines.md
@@ -1,7 +1,16 @@
-# Observability Guidelines
+# Observability Guidelines / Linee Guida per l'Osservabilità
 
-- OpenTelemetry SDK configurato in tutti i servizi (metrics + traces).
-- Esportazione default: OTLP → Tempo, Prometheus scrape, Loki per logs.
-- Ogni servizio espone `/healthz` e `/metrics`.
-- Dashboards Grafana versionate nella cartella `observability/dashboards` (TODO).
-- Stack di osservabilità basato esclusivamente su componenti OSS (Prometheus, Loki, Tempo, Grafana OSS).
+## Telemetry baseline / Baseline di telemetria
+**English:**
+- OpenTelemetry SDK is configured in all services for metrics and traces.
+- Default export path: OTLP → Tempo, Prometheus scrape, Loki for logs.
+- Every service exposes `/healthz` and `/metrics` endpoints.
+- Grafana dashboards are versioned under `observability/dashboards` (TODO).
+- Observability stack relies exclusively on OSS components (Prometheus, Loki, Tempo, Grafana OSS).
+
+**Italiano:**
+- L'SDK OpenTelemetry è configurato in tutti i servizi per metriche e trace.
+- Flusso di esportazione predefinito: OTLP → Tempo, Prometheus per lo scrape, Loki per i log.
+- Ogni servizio espone gli endpoint `/healthz` e `/metrics`.
+- Le dashboard Grafana sono versionate in `observability/dashboards` (TODO).
+- Lo stack di osservabilità si basa esclusivamente su componenti OSS (Prometheus, Loki, Tempo, Grafana OSS).

--- a/docs/08-Data-Guidelines.md
+++ b/docs/08-Data-Guidelines.md
@@ -1,7 +1,16 @@
-# Data Guidelines
+# Data Guidelines / Linee Guida sui Dati
 
-- Timescale schema `telemetry_events` gestito via migrazioni (TODO EF Core migrations).
-- Ignite usato per cache realtime e analytics in-memory.
-- Retention Timescale 365 giorni con compressione.
-- Dati sensibili cifrati at-rest e in-transit.
-- Solo componenti database/cache open source (TimescaleDB OSS, Apache Ignite OSS) per conformità licenze.
+## Storage strategy / Strategia di storage
+**English:**
+- Timescale schema `telemetry_events` managed through migrations (TODO EF Core migrations).
+- Ignite powers realtime cache and in-memory analytics.
+- Timescale retention set to 365 days with compression enabled.
+- Sensitive data encrypted at rest and in transit.
+- Only OSS database/cache components (TimescaleDB OSS, Apache Ignite OSS) to honour licensing requirements.
+
+**Italiano:**
+- Lo schema Timescale `telemetry_events` è gestito tramite migrazioni (TODO EF Core migrations).
+- Ignite alimenta la cache realtime e le analisi in-memory.
+- La retention di Timescale è impostata a 365 giorni con compressione attiva.
+- I dati sensibili sono cifrati at-rest e in-transit.
+- Sono utilizzati solo componenti database/cache OSS (TimescaleDB OSS, Apache Ignite OSS) per rispettare i requisiti di licenza.

--- a/docs/adr/0001.md
+++ b/docs/adr/0001.md
@@ -1,15 +1,27 @@
-# ADR 0001: Utilizzo di .NET Aspire con Dapr per orchestrazione locale
+# ADR 0001: Use .NET Aspire with Dapr for local orchestration / Utilizzo di .NET Aspire con Dapr per l'orchestrazione locale
 
-## Status
-Accepted
+## Status / Stato
+**English:** Accepted
 
-## Context
-Servizi multipli necessitano di essere orchestrati localmente con sidecar Dapr e dipendenze come Kafka e Timescale.
+**Italiano:** Accettata
 
-## Decision
-Adottare .NET Aspire AppHost per definire infrastruttura locale e sidecar Dapr, mantenendo coerenza fra monolite e microservizi.
+## Context / Contesto
+**English:** Multiple services need local orchestration with Dapr sidecars and dependencies such as Kafka and Timescale.
 
-## Consequences
-- Avvio locale semplificato via `dotnet run` sull'AppHost
-- Possibilità di definire dipendenze infra come codice
-- Richiede SDK preview finché Aspire è in preview
+**Italiano:** Più servizi richiedono orchestrazione locale con sidecar Dapr e dipendenze come Kafka e Timescale.
+
+## Decision / Decisione
+**English:** Adopt the .NET Aspire AppHost to define local infrastructure and Dapr sidecars, keeping the monolith and microservice topologies consistent.
+
+**Italiano:** Adottare .NET Aspire AppHost per definire l'infrastruttura locale e i sidecar Dapr, mantenendo coerenti le topologie monolite e microservizi.
+
+## Consequences / Conseguenze
+**English:**
+- Simplified local startup via `dotnet run` on the AppHost.
+- Ability to define infrastructure dependencies as code.
+- Requires preview SDKs while Aspire remains in preview.
+
+**Italiano:**
+- Avvio locale semplificato tramite `dotnet run` sull'AppHost.
+- Possibilità di definire le dipendenze infrastrutturali come codice.
+- Richiede SDK in preview finché Aspire resta in preview.

--- a/docs/adr/0002.md
+++ b/docs/adr/0002.md
@@ -1,15 +1,27 @@
-# ADR 0002: Comunicazioni interne via gRPC + Dapr
+# ADR 0002: Internal communications via gRPC + Dapr / Comunicazioni interne via gRPC + Dapr
 
-## Status
-Accepted
+## Status / Stato
+**English:** Accepted
 
-## Context
-La piattaforma deve rimanere consistente tra modalità monolite e microservizi minimizzando coupling.
+**Italiano:** Accettata
 
-## Decision
-Usare gRPC come protocollo sincrono con Dapr service invocation. I contratti `.proto` sono versionati e riutilizzabili.
+## Context / Contesto
+**English:** The platform must stay consistent between modular monolith and microservice modes while minimising coupling.
 
-## Consequences
-- Contratti fortemente tipizzati riutilizzabili lato client/ server
-- Richiede gestione dei pacchetti generati per front-end/edge
-- Aggiunge complessità per ambienti che non supportano gRPC → fallback REST via gateway
+**Italiano:** La piattaforma deve rimanere consistente tra modalità monolite e microservizi riducendo il coupling.
+
+## Decision / Decisione
+**English:** Use gRPC as the synchronous protocol with Dapr service invocation. `.proto` contracts are versioned and reusable.
+
+**Italiano:** Usare gRPC come protocollo sincrono con invocazione servizi Dapr. I contratti `.proto` sono versionati e riutilizzabili.
+
+## Consequences / Conseguenze
+**English:**
+- Strongly typed contracts reusable by clients and servers.
+- Requires managing generated packages for frontend/edge consumers.
+- Adds complexity for environments without gRPC support → REST gateway fallback.
+
+**Italiano:**
+- Contratti fortemente tipizzati riutilizzabili lato client/server.
+- Richiede la gestione dei pacchetti generati per frontend/edge.
+- Aggiunge complessità negli ambienti che non supportano gRPC → fallback REST via gateway.

--- a/docs/adr/0003.md
+++ b/docs/adr/0003.md
@@ -1,15 +1,27 @@
-# ADR 0003: Kafka come backbone event-driven
+# ADR 0003: Kafka as event-driven backbone / Kafka come backbone event-driven
 
-## Status
-Accepted
+## Status / Stato
+**English:** Accepted
 
-## Context
-Serve un bus altamente scalabile e compatibile con Dapr per orchestrare eventi di telemetria.
+**Italiano:** Accettata
 
-## Decision
-Adottare Kafka con pub/sub Dapr. Topics principali: `telemetry.input`, `telemetry.ingested`.
+## Context / Contesto
+**English:** We need a highly scalable bus compatible with Dapr to orchestrate telemetry events.
 
-## Consequences
-- Supporto nativo Dapr e tool ricco
-- Richiede gestione cluster in produzione
-- Necessario schema registry per evoluzioni (TODO)
+**Italiano:** Serve un bus altamente scalabile e compatibile con Dapr per orchestrare gli eventi di telemetria.
+
+## Decision / Decisione
+**English:** Adopt Kafka with Dapr pub/sub. Main topics: `telemetry.input`, `telemetry.ingested`.
+
+**Italiano:** Adottare Kafka con pub/sub Dapr. Topic principali: `telemetry.input`, `telemetry.ingested`.
+
+## Consequences / Conseguenze
+**English:**
+- Native Dapr support and a rich tooling ecosystem.
+- Requires managed cluster operations in production.
+- Needs a schema registry for evolution (TODO).
+
+**Italiano:**
+- Supporto nativo Dapr e tooling ricco.
+- Richiede la gestione del cluster in produzione.
+- Necessita di uno schema registry per l'evoluzione (TODO).

--- a/docs/adr/0004.md
+++ b/docs/adr/0004.md
@@ -1,14 +1,25 @@
-# ADR 0004: SignalR per notifiche realtime
+# ADR 0004: SignalR for realtime notifications / SignalR per notifiche realtime
 
-## Status
-Accepted
+## Status / Stato
+**English:** Accepted
 
-## Context
-Gli operatori devono ricevere aggiornamenti in tempo reale senza polling.
+**Italiano:** Accettata
 
-## Decision
-Usare SignalR come canale realtime esposto da web-backend-core, integrato con notifier.
+## Context / Contesto
+**English:** Operators must receive real-time updates without relying on polling.
 
-## Consequences
-- Client Angular integrato con @microsoft/signalr
-- Richiede sticky session o backplane in scalabilità orizzontale (Azure SignalR / Redis)
+**Italiano:** Gli operatori devono ricevere aggiornamenti in tempo reale senza ricorrere al polling.
+
+## Decision / Decisione
+**English:** Use SignalR as the realtime channel exposed by web-backend-core, integrated with the notifier service.
+
+**Italiano:** Usare SignalR come canale realtime esposto da web-backend-core, integrato con il servizio notifier.
+
+## Consequences / Conseguenze
+**English:**
+- Angular client integrates via `@microsoft/signalr`.
+- Requires sticky sessions or a backplane for horizontal scale (Azure SignalR / Redis).
+
+**Italiano:**
+- Il client Angular si integra tramite `@microsoft/signalr`.
+- Richiede sticky session o un backplane per la scalabilità orizzontale (Azure SignalR / Redis).

--- a/docs/adr/0005.md
+++ b/docs/adr/0005.md
@@ -1,15 +1,27 @@
-# ADR 0005: TimescaleDB + Apache Ignite per storage ibrido
+# ADR 0005: TimescaleDB + Apache Ignite for hybrid storage / TimescaleDB + Apache Ignite per storage ibrido
 
-## Status
-Accepted
+## Status / Stato
+**English:** Accepted
 
-## Context
-La piattaforma richiede sia persistenza storica time-series sia risposte realtime low-latency.
+**Italiano:** Accettata
 
-## Decision
-Usare TimescaleDB per storage storico e Apache Ignite come data grid/cache condivisa.
+## Context / Contesto
+**English:** The platform needs both historical time-series persistence and low-latency realtime responses.
 
-## Consequences
-- Query analitiche ottimizzate su Timescale
-- Ignite fornisce near-cache e calcoli in-memory
-- Richiede orchestrazione e monitoring dedicato
+**Italiano:** La piattaforma richiede sia persistenza storica time-series sia risposte realtime a bassa latenza.
+
+## Decision / Decisione
+**English:** Use TimescaleDB for historical storage and Apache Ignite as the shared data grid/cache.
+
+**Italiano:** Usare TimescaleDB per lo storage storico e Apache Ignite come data grid/cache condivisa.
+
+## Consequences / Conseguenze
+**English:**
+- Optimised analytical queries on Timescale.
+- Ignite provides near-cache and in-memory computations.
+- Requires dedicated orchestration and monitoring.
+
+**Italiano:**
+- Query analitiche ottimizzate su Timescale.
+- Ignite offre near-cache e calcoli in-memory.
+- Richiede orchestrazione e monitoraggio dedicati.

--- a/docs/devcontainer.md
+++ b/docs/devcontainer.md
@@ -1,32 +1,60 @@
-# Devcontainer Momentum
+# Devcontainer Momentum / Devcontainer di Momentum
 
-La configurazione del Dev Container permette di avere un ambiente riproducibile per lo sviluppo quotidiano della piattaforma Momentum.
+## Purpose / Scopo
+**English:** The Dev Container provides a reproducible environment for day-to-day development on the Momentum platform.
 
-## Contenuto principale
+**Italiano:** Il Dev Container offre un ambiente riproducibile per lo sviluppo quotidiano della piattaforma Momentum.
 
-- **Dockerfile personalizzato** basato su `mcr.microsoft.com/devcontainers/dotnet` con tool di base (`make`, `jq`, `git`, `curl`) utili per build, test e analisi sicurezza.
-- **Feature Node 20** per supportare il frontend Angular 19 e gli script npm.
-- **Supporto Docker-in-Docker** per eseguire `docker compose` direttamente dal container di sviluppo.
-- **Script post-create** che ripristina i pacchetti .NET/Angular e prepara Playwright per gli end-to-end test.
-- **Task VS Code** preconfigurati per `make build`, `make test`, audit dipendenze (`dotnet list ...` e `npm audit`) e linting Angular.
+## Main contents / Contenuti principali
+**English:**
+- **Custom Dockerfile** based on `mcr.microsoft.com/devcontainers/dotnet` with essential tooling (`make`, `jq`, `git`, `curl`) for builds, tests, and security analysis.
+- **Node 20 feature** to support Angular 19 and npm scripts.
+- **Docker-in-Docker support** to run `docker compose` from inside the development container.
+- **Post-create script** restoring .NET/Angular packages and preparing Playwright for end-to-end tests.
+- **VS Code tasks** for `make build`, `make test`, dependency audits (`dotnet list ...`, `npm audit`), and Angular linting.
 
-## Utilizzo
+**Italiano:**
+- **Dockerfile personalizzato** basato su `mcr.microsoft.com/devcontainers/dotnet` con tool essenziali (`make`, `jq`, `git`, `curl`) per build, test e analisi di sicurezza.
+- **Feature Node 20** per supportare Angular 19 e gli script npm.
+- **Supporto Docker-in-Docker** per eseguire `docker compose` dall'interno del container di sviluppo.
+- **Script post-create** che ripristina i pacchetti .NET/Angular e prepara Playwright per i test end-to-end.
+- **Task VS Code** per `make build`, `make test`, audit dipendenze (`dotnet list ...`, `npm audit`) e linting Angular.
 
+## Usage / Utilizzo
+**English:**
+1. Install the [Dev Containers](https://marketplace.visualstudio.com/items?itemName=ms-vscode-remote.remote-containers) extension in VS Code.
+2. Open the repository folder and choose `Dev Containers: Reopen in Container`.
+3. Wait for the bootstrap script to finish. You will have:
+   - .NET and npm dependencies restored;
+   - Playwright ready for end-to-end tests (`make e2e`);
+   - ports 4200/5000/5001/9090 forwarded to the host for frontend, backend, and observability.
+4. Use the available tasks (`Terminal > Run Task...`) to build, test, or run security scans.
+
+**Italiano:**
 1. Installa l'estensione [Dev Containers](https://marketplace.visualstudio.com/items?itemName=ms-vscode-remote.remote-containers) in VS Code.
 2. Apri la cartella del repository e scegli `Dev Containers: Reopen in Container`.
-3. Attendi il completamento dello script di bootstrap. Al termine avrai:
-   - dipendenze .NET e npm già ripristinate;
-   - Playwright pronto per gli end-to-end test (`make e2e`);
+3. Attendi il completamento dello script di bootstrap. Otterrai:
+   - dipendenze .NET e npm ripristinate;
+   - Playwright pronto per i test end-to-end (`make e2e`);
    - porte 4200/5000/5001/9090 inoltrate verso l'host per frontend, backend e osservabilità.
 4. Utilizza i task disponibili (`Terminal > Run Task...`) per build, test o security scan.
 
-## Script disponibili
+## Helper scripts / Script di supporto
+**English:**
+- `.devcontainer/scripts/post-create.sh` – initial provisioning (restore packages, set up Playwright).
+- `.devcontainer/scripts/post-start.sh` – normalises HTTPS certificate permissions and prints the main commands.
+- `.devcontainer/scripts/setup-https-certs.sh` – idempotently creates development HTTPS certificates when missing.
 
+**Italiano:**
 - `.devcontainer/scripts/post-create.sh` – provisioning iniziale (restore pacchetti, setup Playwright).
-- `.devcontainer/scripts/post-start.sh` – normalizza permessi certificati HTTPS e mostra i comandi principali.
+- `.devcontainer/scripts/post-start.sh` – normalizza i permessi dei certificati HTTPS e mostra i comandi principali.
 - `.devcontainer/scripts/setup-https-certs.sh` – crea in modo idempotente i certificati HTTPS di sviluppo se mancanti.
 
-## Note
+## Notes / Note
+**English:**
+- Development HTTPS certificates are mounted from the host into `/home/vscode/.aspnet/https` to maintain ASP.NET compatibility. On Windows the `%USERPROFILE%\.aspnet\https` folder is also mounted and exposed inside the container.
+- To update Playwright or install additional browsers run `npx playwright install --with-deps` inside the container.
 
-- I certificati di sviluppo HTTPS sono montati dalla macchina host in `/home/vscode/.aspnet/https` per mantenere la compatibilità con ASP.NET. Su Windows viene montata anche la cartella `%USERPROFILE%\.aspnet\https` e resa disponibile nel container.
-- Per aggiornare Playwright o installare browser aggiuntivi eseguire `npx playwright install --with-deps` all'interno del container.
+**Italiano:**
+- I certificati HTTPS di sviluppo sono montati dalla macchina host in `/home/vscode/.aspnet/https` per mantenere la compatibilità con ASP.NET. Su Windows viene montata anche la cartella `%USERPROFILE%\.aspnet\https` e resa disponibile nel container.
+- Per aggiornare Playwright o installare browser aggiuntivi esegui `npx playwright install --with-deps` all'interno del container.

--- a/modules/ticketing/README.md
+++ b/modules/ticketing/README.md
@@ -1,3 +1,5 @@
-# Ticketing Module
+# Ticketing Module / Modulo Ticketing
 
-Example plug-in module exposing OpenAPI contract via Dapr invocation. The module can be hosted as part of the monolith or independently.
+**English:** Example plug-in module exposing an OpenAPI contract via Dapr invocation. It can run inside the monolith or independently.
+
+**Italiano:** Modulo plug-in di esempio che espone un contratto OpenAPI tramite invocazione Dapr. Può essere eseguito all'interno del monolite o in modo indipendente.

--- a/tools/issue_management/README.md
+++ b/tools/issue_management/README.md
@@ -1,13 +1,11 @@
-# Issue management automation
+# Issue management automation / Automazione della gestione issue
 
-Lo script `ensure_issue_links.py` viene eseguito come parte della pipeline di verifica delle
-pull request per controllare che ogni commit sia collegato ad almeno una issue. Quando il
-parametro `--auto-create` è abilitato e sono disponibili le variabili `GITHUB_TOKEN` e
-`OPENAI_API_KEY`, il tool genera automaticamente una nuova issue riassumendo il commit e
-aggiorna il corpo della pull request aggiungendo il riferimento `Fixes #<numero>`.
+## Purpose / Scopo
+**English:** `ensure_issue_links.py` runs as part of the pull request validation pipeline to ensure every commit links to at least one issue. With `--auto-create` and the `GITHUB_TOKEN`/`OPENAI_API_KEY` variables available, the tool creates a new issue summarising the commit and updates the PR body with `Fixes #<number>`.
 
-## Esecuzione manuale
+**Italiano:** `ensure_issue_links.py` viene eseguito nella pipeline di verifica delle pull request per garantire che ogni commit sia collegato ad almeno una issue. Con `--auto-create` e le variabili `GITHUB_TOKEN`/`OPENAI_API_KEY` disponibili, lo strumento crea una nuova issue con il riassunto del commit e aggiorna il corpo della PR con `Fixes #<numero>`.
 
+## Manual execution / Esecuzione manuale
 ```bash
 python tools/issue_management/ensure_issue_links.py \
   --repo <owner>/<repository> \
@@ -15,12 +13,14 @@ python tools/issue_management/ensure_issue_links.py \
   --auto-create
 ```
 
-Il comando restituisce uno stato di errore se sono presenti commit senza riferimento ad una
-issue. In modalità automatica viene creato un ticket con il riassunto delle modifiche.
+**English:** The command returns an error status when commits lack issue references. In auto mode it opens a ticket with the summary.
 
-Dipendenze Python:
+**Italiano:** Il comando restituisce uno stato di errore se sono presenti commit senza riferimento a una issue. In modalità automatica apre un ticket con il riassunto.
+
+**English:** Install Python dependencies with:
+
+**Italiano:** Installa le dipendenze Python con:
 
 ```bash
 pip install -r tools/issue_management/requirements.txt
 ```
-

--- a/tools/release_notes/README.md
+++ b/tools/release_notes/README.md
@@ -1,10 +1,11 @@
-# Release notes automation
+# Release notes automation / Automazione delle release notes
 
-Questo modulo contiene lo script `generate_release_notes.py` utilizzato sia localmente sia
-nell'automazione GitHub per produrre file di release note per progetto e moduli.
+## Purpose / Scopo
+**English:** This module contains `generate_release_notes.py`, used locally and in GitHub automation to produce release note files for the project and its modules.
 
-## Utilizzo locale
+**Italiano:** Questo modulo contiene `generate_release_notes.py`, usato localmente e nell'automazione GitHub per produrre i file di release note per il progetto e i moduli.
 
+## Local usage / Utilizzo locale
 ```bash
 python tools/release_notes/generate_release_notes.py \
   --release-version 1.0.0 \
@@ -14,26 +15,34 @@ python tools/release_notes/generate_release_notes.py \
   --github-token $GITHUB_TOKEN
 ```
 
-I file vengono creati nella cartella `ReleaseNotes` a livello di repository e nella
-cartella `ReleaseNotes` di ciascun modulo sotto `modules/<nome-modulo>/`.
+**English:** Files are generated under the repository-level `ReleaseNotes` folder and inside each module at `modules/<module-name>/ReleaseNotes/`.
 
-Installare le dipendenze Python con:
+**Italiano:** I file vengono creati nella cartella `ReleaseNotes` del repository e nella cartella `modules/<nome-modulo>/ReleaseNotes/` di ciascun modulo.
+
+**English:** Install Python dependencies with:
+
+**Italiano:** Installa le dipendenze Python con:
 
 ```bash
 pip install -r tools/release_notes/requirements.txt
 ```
 
-## Creazione automatica della release
+## Automated release creation / Creazione automatica della release
+**English:** `tools/release_notes/create_release.py` automates the whole flow:
+1. Determines the next version using semantic rules by analysing commits since the latest tag.
+2. Generates release notes enriched with GitHub issue titles.
+3. Creates a `chore: release <version>` commit containing the generated files.
+4. Tags `v<version>` on `main` and creates the `release/v<version>` branch.
 
-Lo script `tools/release_notes/create_release.py` automatizza l'intero flusso:
-
-1. Determina il prossimo numero di versione seguendo la policy semantica analizzando i commit
-   dall'ultimo tag.
-2. Genera i file di release notes arricchiti con i titoli delle issue di GitHub.
+**Italiano:** `tools/release_notes/create_release.py` automatizza l'intero flusso:
+1. Determina il prossimo numero di versione secondo le regole semantiche analizzando i commit dall'ultimo tag.
+2. Genera le release notes arricchite con i titoli delle issue GitHub.
 3. Crea un commit `chore: release <version>` con i file prodotti.
 4. Applica il tag `v<version>` su `main` e crea il branch `release/v<version>`.
 
-Esempio di esecuzione:
+**English:** Example run:
+
+**Italiano:** Esempio di esecuzione:
 
 ```bash
 python -m tools.release_notes.create_release \
@@ -41,5 +50,6 @@ python -m tools.release_notes.create_release \
   --github-token $GITHUB_TOKEN
 ```
 
-È necessario che il working tree sia pulito e che il comando venga lanciato dal branch `main`.
+**English:** Ensure the working tree is clean and execute the command from the `main` branch.
 
+**Italiano:** Assicurati che il working tree sia pulito ed esegui il comando dal branch `main`.


### PR DESCRIPTION
## Summary
- translate and expand the main README and architecture overview with bilingual English/Italian sections, including repository configuration details
- update policies, guidelines, ADRs, and devcontainer documentation to provide matched bilingual content and clarify workflows
- refresh module and tooling READMEs so all developer documentation follows the same bilingual convention

## Testing
- not run (documentation changes only)

------
https://chatgpt.com/codex/tasks/task_e_68ebc9c663bc8333892072c62836627f
- Closes #85 (commit 813c651)