### PR TITLE
Fix Grpc.Tools path guard in Identifier API

### DIFF
--- a/src/services/identifier/Identifier.Api/Identifier.Api.csproj
+++ b/src/services/identifier/Identifier.Api/Identifier.Api.csproj
@@ -16,13 +16,12 @@
     <PackageReference Include="Grpc.Tools" PrivateAssets="All" GeneratePathProperty="true" />
   </ItemGroup>
 
-  <PropertyGroup>
+  <PropertyGroup Condition="'$(PkgGrpc_Tools)' != ''">
     <!-- 1) imposta la base degli strumenti -->
-    <Protobuf_Tools_Path>$(PkgGrpc_Tools)\tools</Protobuf_Tools_Path>
-    <!-- 2) imposta il binario completo (Windows) -->
-    <Protobuf_ProtocFullPath Condition="'$(OS)'=='Windows_NT'">$(PkgGrpc_Tools)\tools\windows_x64\protoc.exe</Protobuf_ProtocFullPath>
-    <Protobuf_ProtocFullPath Condition="'$(OS)'!='Windows_NT'">$(PkgGrpc_Tools)\tools\linux_x64\protoc</Protobuf_ProtocFullPath>
-    
+    <Protobuf_Tools_Path>$(PkgGrpc_Tools)/tools</Protobuf_Tools_Path>
+    <!-- 2) imposta il binario completo in base al sistema operativo -->
+    <Protobuf_ProtocFullPath Condition="'$(OS)'=='Windows_NT'">$(PkgGrpc_Tools)/tools/windows_x64/protoc.exe</Protobuf_ProtocFullPath>
+    <Protobuf_ProtocFullPath Condition="'$(OS)'!='Windows_NT'">$(PkgGrpc_Tools)/tools/linux_x64/protoc</Protobuf_ProtocFullPath>
   </PropertyGroup>
   <ItemGroup>
     <Protobuf Include="../../../../contracts/identifier/authentication.proto" GrpcServices="Server" Link="Protos/authentication.proto" />


### PR DESCRIPTION
## Summary
- guard the custom protoc path configuration so it is only applied when the Grpc.Tools package directory is available
- switch to OS-agnostic path separators when selecting the platform-specific protoc binary

## Testing
- not run (dotnet CLI not available in container)


------
https://chatgpt.com/codex/tasks/task_e_68ed5977a90c8333a5816aaeb078a920