### PR TITLE
Add modular monolith service

### DIFF
--- a/Momentum.sln
+++ b/Momentum.sln
@@ -36,6 +36,16 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "WebBackendCore.Infrastructu
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "WebBackendCore.Api", "src\services\web-backend-core\WebBackendCore.Api\WebBackendCore.Api.csproj", "{EDBC74C7-AED3-45B6-9B42-55533F6F3714}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "ModularMonolith.Domain", "src\services\modular-monolith\ModularMonolith.Domain\ModularMonolith.Domain.csproj", "{05B6B399-FF4A-44A4-B600-2AC381B64A63}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "ModularMonolith.Application", "src\services\modular-monolith\ModularMonolith.Application\ModularMonolith.Application.csproj", "{3658BBF4-08E9-451A-9C3C-B6E22A87FC90}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "ModularMonolith.Infrastructure", "src\services\modular-monolith\ModularMonolith.Infrastructure\ModularMonolith.Infrastructure.csproj", "{7DDF0F3A-A605-4AB0-A461-8E1C280F77A4}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "ModularMonolith.Api", "src\services\modular-monolith\ModularMonolith.Api\ModularMonolith.Api.csproj", "{CF457BE7-A389-4A05-8A66-96BE599AB7D4}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "ModularMonolith.Application.Tests", "tests\ModularMonolith\ModularMonolith.Application.Tests\ModularMonolith.Application.Tests.csproj", "{49C6ADA0-9B10-4CF4-B833-472CC087767A}"
+EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Streamer.Application.Tests", "tests\Streamer\Streamer.Application.Tests\Streamer.Application.Tests.csproj", "{6F9FA50F-9BFA-4BAE-A908-4E822773494F}"
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Notifier.Api.Integration", "tests\Notifier\Notifier.Api.Integration\Notifier.Api.Integration.csproj", "{FAD912A8-3ED0-44AB-A937-B58BA845CBE1}"
@@ -114,6 +124,26 @@ GlobalSection(ProjectConfigurationPlatforms) = postSolution
 {EDBC74C7-AED3-45B6-9B42-55533F6F3714}.Debug|Any CPU.Build.0 = Debug|Any CPU
 {EDBC74C7-AED3-45B6-9B42-55533F6F3714}.Release|Any CPU.ActiveCfg = Release|Any CPU
 {EDBC74C7-AED3-45B6-9B42-55533F6F3714}.Release|Any CPU.Build.0 = Release|Any CPU
+{05B6B399-FF4A-44A4-B600-2AC381B64A63}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+{05B6B399-FF4A-44A4-B600-2AC381B64A63}.Debug|Any CPU.Build.0 = Debug|Any CPU
+{05B6B399-FF4A-44A4-B600-2AC381B64A63}.Release|Any CPU.ActiveCfg = Release|Any CPU
+{05B6B399-FF4A-44A4-B600-2AC381B64A63}.Release|Any CPU.Build.0 = Release|Any CPU
+{3658BBF4-08E9-451A-9C3C-B6E22A87FC90}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+{3658BBF4-08E9-451A-9C3C-B6E22A87FC90}.Debug|Any CPU.Build.0 = Debug|Any CPU
+{3658BBF4-08E9-451A-9C3C-B6E22A87FC90}.Release|Any CPU.ActiveCfg = Release|Any CPU
+{3658BBF4-08E9-451A-9C3C-B6E22A87FC90}.Release|Any CPU.Build.0 = Release|Any CPU
+{7DDF0F3A-A605-4AB0-A461-8E1C280F77A4}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+{7DDF0F3A-A605-4AB0-A461-8E1C280F77A4}.Debug|Any CPU.Build.0 = Debug|Any CPU
+{7DDF0F3A-A605-4AB0-A461-8E1C280F77A4}.Release|Any CPU.ActiveCfg = Release|Any CPU
+{7DDF0F3A-A605-4AB0-A461-8E1C280F77A4}.Release|Any CPU.Build.0 = Release|Any CPU
+{CF457BE7-A389-4A05-8A66-96BE599AB7D4}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+{CF457BE7-A389-4A05-8A66-96BE599AB7D4}.Debug|Any CPU.Build.0 = Debug|Any CPU
+{CF457BE7-A389-4A05-8A66-96BE599AB7D4}.Release|Any CPU.ActiveCfg = Release|Any CPU
+{CF457BE7-A389-4A05-8A66-96BE599AB7D4}.Release|Any CPU.Build.0 = Release|Any CPU
+{49C6ADA0-9B10-4CF4-B833-472CC087767A}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+{49C6ADA0-9B10-4CF4-B833-472CC087767A}.Debug|Any CPU.Build.0 = Debug|Any CPU
+{49C6ADA0-9B10-4CF4-B833-472CC087767A}.Release|Any CPU.ActiveCfg = Release|Any CPU
+{49C6ADA0-9B10-4CF4-B833-472CC087767A}.Release|Any CPU.Build.0 = Release|Any CPU
 {6F9FA50F-9BFA-4BAE-A908-4E822773494F}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
 {6F9FA50F-9BFA-4BAE-A908-4E822773494F}.Debug|Any CPU.Build.0 = Debug|Any CPU
 {6F9FA50F-9BFA-4BAE-A908-4E822773494F}.Release|Any CPU.ActiveCfg = Release|Any CPU

--- a/README.md
+++ b/README.md
@@ -60,6 +60,7 @@ dotnet run --project src/AppHost/Momentum.AppHost.csproj
 | streamer | Telemetry ingestion from Kafka → Timescale/Ignite |
 | notifier | Multi-channel notification dispatch |
 | web-backend-core | API gateway + SignalR hub |
+| modular-monolith | Aggregates all backend capabilities via Dapr |
 | web-core | Modular Angular frontend |
 
 **Italiano:**
@@ -69,6 +70,7 @@ dotnet run --project src/AppHost/Momentum.AppHost.csproj
 | streamer | Ingest telemetria da Kafka → Timescale/Ignite |
 | notifier | Invio notifiche multi-canale |
 | web-backend-core | Gateway API + hub SignalR |
+| modular-monolith | Aggrega tutte le capability backend tramite Dapr |
 | web-core | Frontend modulare Angular |
 
 ## End-to-end flow / Flusso end-to-end

--- a/architecture-overview.md
+++ b/architecture-overview.md
@@ -13,6 +13,7 @@
 **English:**
 - **web-core (Angular):** shell consuming SignalR and federated modules.
 - **web-backend-core (.NET):** API gateway + SignalR hub + OpenFeature integration.
+- **modular-monolith (.NET):** Unified façade invoking all services via Dapr.
 - **identifier service:** gRPC auth, JWT minting.
 - **streamer service:** Kafka consumer, TimescaleDB persistence, Ignite cache.
 - **notifier service:** Subscribes to `telemetry.ingested`, dispatches email/SignalR.
@@ -21,6 +22,7 @@
 **Italiano:**
 - **web-core (Angular):** shell che consuma SignalR e moduli federati.
 - **web-backend-core (.NET):** API gateway + hub SignalR + integrazione OpenFeature.
+- **modular-monolith (.NET):** Facciata unificata che invoca tutti i servizi tramite Dapr.
 - **identifier service:** autenticazione gRPC, emissione JWT.
 - **streamer service:** consumer Kafka, persistenza TimescaleDB, cache Ignite.
 - **notifier service:** si sottoscrive a `telemetry.ingested`, inoltra email/SignalR.

--- a/src/AppHost/AppHost.cs
+++ b/src/AppHost/AppHost.cs
@@ -80,6 +80,13 @@ var notifier = builder.AddProject<Projects.Notifier_Api>("notifier-api")
 var backend = builder.AddProject<Projects.WebBackendCore_Api>("web-backend-core")
     .WithDaprSidecar();
 
+var modularMonolith = builder.AddProject<Projects.ModularMonolith_Api>("modular-monolith")
+    .WithDaprSidecar()
+    .WithReference(identifier)
+    .WithReference(streamer)
+    .WithReference(notifier)
+    .WithReference(backend);
+
 var angular = builder.AddExecutable("web-core", "npm", "run", "start")
     .WithWorkingDirectory("../src/web-core")
     .WithHttpEndpoint(port: 4200, targetPort: 4200, isProxied: false);

--- a/src/AppHost/Momentum.AppHost.csproj
+++ b/src/AppHost/Momentum.AppHost.csproj
@@ -21,6 +21,7 @@
     <ProjectReference Include="..\services\streamer\streamer.Api\Streamer.Api.csproj" />
     <ProjectReference Include="..\services\notifier\notifier.Api\Notifier.Api.csproj" />
     <ProjectReference Include="..\services\web-backend-core\WebBackendCore.Api\WebBackendCore.Api.csproj" />
+    <ProjectReference Include="..\services\modular-monolith\ModularMonolith.Api\ModularMonolith.Api.csproj" />
 
     <Compile Include="..\shared\DevCertHostingExtensions.cs" Link="DevCertHostingExtensions.cs" />
   </ItemGroup>

--- a/src/services/modular-monolith/ModularMonolith.Api/Controllers/ModulesController.cs
+++ b/src/services/modular-monolith/ModularMonolith.Api/Controllers/ModulesController.cs
@@ -1,0 +1,34 @@
+using Microsoft.AspNetCore.Mvc;
+using ModularMonolith.Application.Modules;
+
+namespace ModularMonolith.Api.Controllers;
+
+[ApiController]
+[Route("api/modules")]
+public sealed class ModulesController : ControllerBase
+{
+    private readonly GetModuleStatusQuery _query;
+
+    public ModulesController(GetModuleStatusQuery query)
+    {
+        _query = query;
+    }
+
+    [HttpGet("status")]
+    [ProducesResponseType(typeof(IReadOnlyCollection<ModuleStatusResponse>), StatusCodes.Status200OK)]
+    public async Task<ActionResult<IReadOnlyCollection<ModuleStatusResponse>>> GetStatusAsync(CancellationToken cancellationToken)
+    {
+        var statuses = await _query.ExecuteAsync(cancellationToken);
+        var response = statuses.Select(ModuleStatusResponse.FromDomain).ToArray();
+        return Ok(response);
+    }
+}
+
+public sealed record ModuleStatusResponse(string Name, string Description, bool Healthy, string Details)
+{
+    public static ModuleStatusResponse FromDomain(ModuleStatus status) => new(
+        status.Registration.Name,
+        status.Registration.Description,
+        status.Healthy,
+        status.Details);
+}

--- a/src/services/modular-monolith/ModularMonolith.Api/Dockerfile
+++ b/src/services/modular-monolith/ModularMonolith.Api/Dockerfile
@@ -1,0 +1,21 @@
+FROM mcr.microsoft.com/dotnet/aspnet:8.0 AS base
+WORKDIR /app
+EXPOSE 8080
+
+FROM mcr.microsoft.com/dotnet/sdk:8.0 AS build
+WORKDIR /src
+
+COPY Momentum.sln ./
+COPY src/services/modular-monolith/ModularMonolith.Domain/ModularMonolith.Domain.csproj src/services/modular-monolith/ModularMonolith.Domain/
+COPY src/services/modular-monolith/ModularMonolith.Application/ModularMonolith.Application.csproj src/services/modular-monolith/ModularMonolith.Application/
+COPY src/services/modular-monolith/ModularMonolith.Infrastructure/ModularMonolith.Infrastructure.csproj src/services/modular-monolith/ModularMonolith.Infrastructure/
+COPY src/services/modular-monolith/ModularMonolith.Api/ModularMonolith.Api.csproj src/services/modular-monolith/ModularMonolith.Api/
+RUN dotnet restore src/services/modular-monolith/ModularMonolith.Api/ModularMonolith.Api.csproj
+
+COPY . .
+RUN dotnet publish src/services/modular-monolith/ModularMonolith.Api/ModularMonolith.Api.csproj -c Release -o /app/out /p:UseAppHost=false
+
+FROM base AS final
+WORKDIR /app
+COPY --from=build /app/out .
+ENTRYPOINT ["dotnet", "ModularMonolith.Api.dll"]

--- a/src/services/modular-monolith/ModularMonolith.Api/ModularMonolith.Api.csproj
+++ b/src/services/modular-monolith/ModularMonolith.Api/ModularMonolith.Api.csproj
@@ -1,0 +1,19 @@
+<Project Sdk="Microsoft.NET.Sdk.Web">
+  <PropertyGroup>
+    <TargetFramework>net8.0</TargetFramework>
+    <Nullable>enable</Nullable>
+    <ImplicitUsings>enable</ImplicitUsings>
+  </PropertyGroup>
+  <ItemGroup>
+    <PackageReference Include="Dapr.AspNetCore" />
+    <PackageReference Include="OpenTelemetry.Extensions.Hosting" />
+    <PackageReference Include="OpenTelemetry.Instrumentation.AspNetCore" />
+    <PackageReference Include="OpenTelemetry.Exporter.Prometheus.AspNetCore" />
+    <PackageReference Include="OpenTelemetry.Instrumentation.Http" />
+    <PackageReference Include="Swashbuckle.AspNetCore" />
+  </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="../ModularMonolith.Application/ModularMonolith.Application.csproj" />
+    <ProjectReference Include="../ModularMonolith.Infrastructure/ModularMonolith.Infrastructure.csproj" />
+  </ItemGroup>
+</Project>

--- a/src/services/modular-monolith/ModularMonolith.Api/Program.cs
+++ b/src/services/modular-monolith/ModularMonolith.Api/Program.cs
@@ -1,0 +1,50 @@
+using ModularMonolith.Application.Modules;
+using ModularMonolith.Infrastructure.Modules;
+using ModularMonolith.Infrastructure.Options;
+using OpenTelemetry.Metrics;
+using OpenTelemetry.Resources;
+using OpenTelemetry.Trace;
+
+var builder = WebApplication.CreateBuilder(args);
+
+builder.Services.AddControllers();
+builder.Services.AddEndpointsApiExplorer();
+builder.Services.AddSwaggerGen();
+builder.Services.AddDaprClient();
+
+builder.Services
+    .AddOptions<MonolithOptions>()
+    .Bind(builder.Configuration.GetSection("Monolith"))
+    .ValidateDataAnnotations()
+    .Validate(options => options.Modules.Count > 0, "At least one module must be configured")
+    .ValidateOnStart();
+
+builder.Services.AddSingleton<IModuleStatusProvider, DaprModuleStatusProvider>();
+builder.Services.AddSingleton<GetModuleStatusQuery>();
+
+builder.Services.AddOpenTelemetry()
+    .ConfigureResource(resource => resource.AddService("modular-monolith-api"))
+    .WithMetrics(metrics => metrics.AddAspNetCoreInstrumentation().AddPrometheusExporter())
+    .WithTracing(tracing => tracing.AddAspNetCoreInstrumentation());
+
+builder.Services.AddHealthChecks();
+
+var app = builder.Build();
+
+if (app.Environment.IsDevelopment())
+{
+    app.UseSwagger();
+    app.UseSwaggerUI();
+}
+
+app.MapControllers();
+app.MapHealthChecks("/healthz");
+app.MapGet("/", () => "Modular monolith ready");
+app.MapGet("/metrics", () => Results.Ok("Prometheus metrics"));
+
+app.Run();
+
+public partial class Program
+{
+    public static string Name => "ModularMonolith";
+}

--- a/src/services/modular-monolith/ModularMonolith.Api/appsettings.json
+++ b/src/services/modular-monolith/ModularMonolith.Api/appsettings.json
@@ -1,0 +1,30 @@
+{
+  "Monolith": {
+    "Modules": [
+      {
+        "Name": "identifier",
+        "Description": "Authentication and license management",
+        "AppId": "identifier-api",
+        "HealthEndpoint": "healthz"
+      },
+      {
+        "Name": "streamer",
+        "Description": "Telemetry ingestion from Kafka to Timescale and Ignite",
+        "AppId": "streamer-api",
+        "HealthEndpoint": "healthz"
+      },
+      {
+        "Name": "notifier",
+        "Description": "Notification dispatch across email and realtime channels",
+        "AppId": "notifier-api",
+        "HealthEndpoint": "healthz"
+      },
+      {
+        "Name": "web-backend-core",
+        "Description": "API gateway exposing SignalR and orchestrations",
+        "AppId": "web-backend-core",
+        "HealthEndpoint": "healthz"
+      }
+    ]
+  }
+}

--- a/src/services/modular-monolith/ModularMonolith.Application/ModularMonolith.Application.csproj
+++ b/src/services/modular-monolith/ModularMonolith.Application/ModularMonolith.Application.csproj
@@ -1,0 +1,10 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net8.0</TargetFramework>
+    <Nullable>enable</Nullable>
+    <ImplicitUsings>enable</ImplicitUsings>
+  </PropertyGroup>
+  <ItemGroup>
+    <ProjectReference Include="../ModularMonolith.Domain/ModularMonolith.Domain.csproj" />
+  </ItemGroup>
+</Project>

--- a/src/services/modular-monolith/ModularMonolith.Application/Modules/GetModuleStatusQuery.cs
+++ b/src/services/modular-monolith/ModularMonolith.Application/Modules/GetModuleStatusQuery.cs
@@ -1,0 +1,14 @@
+namespace ModularMonolith.Application.Modules;
+
+public sealed class GetModuleStatusQuery
+{
+    private readonly IModuleStatusProvider _provider;
+
+    public GetModuleStatusQuery(IModuleStatusProvider provider)
+    {
+        _provider = provider;
+    }
+
+    public Task<IReadOnlyCollection<ModuleStatus>> ExecuteAsync(CancellationToken cancellationToken = default)
+        => _provider.GetStatusesAsync(cancellationToken);
+}

--- a/src/services/modular-monolith/ModularMonolith.Application/Modules/IModuleStatusProvider.cs
+++ b/src/services/modular-monolith/ModularMonolith.Application/Modules/IModuleStatusProvider.cs
@@ -1,0 +1,8 @@
+using ModularMonolith.Domain.Modules;
+
+namespace ModularMonolith.Application.Modules;
+
+public interface IModuleStatusProvider
+{
+    Task<IReadOnlyCollection<ModuleStatus>> GetStatusesAsync(CancellationToken cancellationToken);
+}

--- a/src/services/modular-monolith/ModularMonolith.Application/Modules/ModuleStatus.cs
+++ b/src/services/modular-monolith/ModularMonolith.Application/Modules/ModuleStatus.cs
@@ -1,0 +1,5 @@
+using ModularMonolith.Domain.Modules;
+
+namespace ModularMonolith.Application.Modules;
+
+public sealed record ModuleStatus(ModuleRegistration Registration, bool Healthy, string Details);

--- a/src/services/modular-monolith/ModularMonolith.Domain/ModularMonolith.Domain.csproj
+++ b/src/services/modular-monolith/ModularMonolith.Domain/ModularMonolith.Domain.csproj
@@ -1,0 +1,7 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net8.0</TargetFramework>
+    <Nullable>enable</Nullable>
+    <ImplicitUsings>enable</ImplicitUsings>
+  </PropertyGroup>
+</Project>

--- a/src/services/modular-monolith/ModularMonolith.Domain/Modules/ModuleRegistration.cs
+++ b/src/services/modular-monolith/ModularMonolith.Domain/Modules/ModuleRegistration.cs
@@ -1,0 +1,7 @@
+namespace ModularMonolith.Domain.Modules;
+
+public sealed record ModuleRegistration(
+    string Name,
+    string Description,
+    string AppId,
+    string HealthEndpoint);

--- a/src/services/modular-monolith/ModularMonolith.Infrastructure/ModularMonolith.Infrastructure.csproj
+++ b/src/services/modular-monolith/ModularMonolith.Infrastructure/ModularMonolith.Infrastructure.csproj
@@ -1,0 +1,15 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net8.0</TargetFramework>
+    <Nullable>enable</Nullable>
+    <ImplicitUsings>enable</ImplicitUsings>
+  </PropertyGroup>
+  <ItemGroup>
+    <PackageReference Include="Dapr.Client" />
+    <PackageReference Include="Microsoft.Extensions.Options.ConfigurationExtensions" />
+  </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="../ModularMonolith.Application/ModularMonolith.Application.csproj" />
+    <ProjectReference Include="../ModularMonolith.Domain/ModularMonolith.Domain.csproj" />
+  </ItemGroup>
+</Project>

--- a/src/services/modular-monolith/ModularMonolith.Infrastructure/Modules/DaprModuleStatusProvider.cs
+++ b/src/services/modular-monolith/ModularMonolith.Infrastructure/Modules/DaprModuleStatusProvider.cs
@@ -1,0 +1,58 @@
+using System.Net.Http;
+using Dapr.Client;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
+using ModularMonolith.Application.Modules;
+using ModularMonolith.Infrastructure.Options;
+
+namespace ModularMonolith.Infrastructure.Modules;
+
+public sealed class DaprModuleStatusProvider : IModuleStatusProvider
+{
+    private readonly DaprClient _daprClient;
+    private readonly MonolithOptions _options;
+    private readonly ILogger<DaprModuleStatusProvider> _logger;
+
+    public DaprModuleStatusProvider(
+        DaprClient daprClient,
+        IOptions<MonolithOptions> options,
+        ILogger<DaprModuleStatusProvider> logger)
+    {
+        _daprClient = daprClient;
+        _options = options.Value;
+        _logger = logger;
+    }
+
+    public async Task<IReadOnlyCollection<ModuleStatus>> GetStatusesAsync(CancellationToken cancellationToken)
+    {
+        var registrations = _options.ToRegistrations();
+        var statuses = new List<ModuleStatus>(registrations.Count);
+
+        foreach (var registration in registrations)
+        {
+            var healthy = false;
+            var details = "Module unreachable";
+
+            try
+            {
+                await _daprClient.InvokeMethodAsync(HttpMethod.Get, registration.AppId, registration.HealthEndpoint, cancellationToken);
+                healthy = true;
+                details = "Healthy";
+            }
+            catch (InvocationException ex)
+            {
+                _logger.LogWarning(ex, "Failed to reach module {ModuleName} via Dapr", registration.Name);
+                details = ex.InnerException?.Message ?? ex.Message;
+            }
+            catch (Exception ex)
+            {
+                _logger.LogError(ex, "Unexpected error while invoking module {ModuleName}", registration.Name);
+                details = ex.Message;
+            }
+
+            statuses.Add(new ModuleStatus(registration, healthy, details));
+        }
+
+        return statuses;
+    }
+}

--- a/src/services/modular-monolith/ModularMonolith.Infrastructure/Options/MonolithOptions.cs
+++ b/src/services/modular-monolith/ModularMonolith.Infrastructure/Options/MonolithOptions.cs
@@ -1,0 +1,33 @@
+using System.ComponentModel.DataAnnotations;
+using ModularMonolith.Domain.Modules;
+
+namespace ModularMonolith.Infrastructure.Options;
+
+public sealed class MonolithOptions
+{
+    [Required]
+    public ICollection<ModuleOption> Modules { get; init; } = new List<ModuleOption>();
+
+    public IReadOnlyCollection<ModuleRegistration> ToRegistrations()
+        => Modules
+            .Select(module => new ModuleRegistration(
+                module.Name!,
+                module.Description!,
+                module.AppId!,
+                module.HealthEndpoint ?? "healthz"))
+            .ToArray();
+}
+
+public sealed class ModuleOption
+{
+    [Required]
+    public string? Name { get; init; }
+
+    [Required]
+    public string? Description { get; init; }
+
+    [Required]
+    public string? AppId { get; init; }
+
+    public string? HealthEndpoint { get; init; }
+}

--- a/tests/ModularMonolith/ModularMonolith.Application.Tests/GetModuleStatusQueryTests.cs
+++ b/tests/ModularMonolith/ModularMonolith.Application.Tests/GetModuleStatusQueryTests.cs
@@ -1,0 +1,28 @@
+using System.Threading;
+using ModularMonolith.Application.Modules;
+using ModularMonolith.Domain.Modules;
+using Moq;
+using Xunit;
+
+namespace ModularMonolith.Application.Tests;
+
+public sealed class GetModuleStatusQueryTests
+{
+    [Fact]
+    public async Task ExecuteAsync_ReturnsStatusesFromProvider()
+    {
+        var registration = new ModuleRegistration("identifier", "Authentication", "identifier-api", "healthz");
+        var expected = new ModuleStatus(registration, true, "Healthy");
+
+        var provider = new Mock<IModuleStatusProvider>();
+        provider
+            .Setup(p => p.GetStatusesAsync(It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new[] { expected });
+
+        var query = new GetModuleStatusQuery(provider.Object);
+        var result = await query.ExecuteAsync();
+
+        Assert.Single(result);
+        Assert.Equal(expected, result.Single());
+    }
+}

--- a/tests/ModularMonolith/ModularMonolith.Application.Tests/ModularMonolith.Application.Tests.csproj
+++ b/tests/ModularMonolith/ModularMonolith.Application.Tests/ModularMonolith.Application.Tests.csproj
@@ -1,0 +1,16 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net8.0</TargetFramework>
+    <IsPackable>false</IsPackable>
+  </PropertyGroup>
+  <ItemGroup>
+    <PackageReference Include="xunit" />
+    <PackageReference Include="xunit.runner.visualstudio" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" />
+    <PackageReference Include="Moq" />
+  </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="../../../src/services/modular-monolith/ModularMonolith.Application/ModularMonolith.Application.csproj" />
+    <ProjectReference Include="../../../src/services/modular-monolith/ModularMonolith.Domain/ModularMonolith.Domain.csproj" />
+  </ItemGroup>
+</Project>


### PR DESCRIPTION
## Summary
- create the modular monolith service with domain, application, infrastructure, and API layers to orchestrate existing modules
- add a Dapr-backed module status provider, HTTP controller, and configuration along with Docker packaging and unit coverage
- wire the new service into the Aspire AppHost and update documentation to describe the modular monolith container

## Testing
- `dotnet test` *(fails: dotnet CLI is unavailable in the execution environment)*

------
https://chatgpt.com/codex/tasks/task_e_68ee93c27d2883339afcb148bedde179