### PR TITLE
Refine documentation for modular monolith guidance

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,12 +1,9 @@
-# Momentum Platform / Piattaforma Momentum
+# Momentum Platform
 
-## Overview / Panoramica
-**English:** Momentum is a modular and resilient platform that can run as a modular monolith or evolve into a microservice topology without changing public contracts.
-
-**Italiano:** Momentum è una piattaforma modulare e resiliente che può funzionare come monolite modulare oppure evolvere in una topologia a microservizi senza modificare i contratti pubblici.
+## Overview
+Momentum is a modular and resilient platform that can operate as a modular monolith or evolve into a microservice topology without changing public contracts. The `modular-monolith` service provides the reference implementation for the aggregated runtime, and developers should follow the dedicated [Modular Architecture Guidelines](docs/06-Modular-Architecture-Guidelines.md) when extending it. Additional architectural context is available in the [architecture overview](architecture-overview.md).
 
 ## Stack
-**English:**
 - **Backend:** .NET 8 Aspire with Dapr over gRPC and Kafka pub/sub.
 - **Frontend:** Angular 19 (standalone, i18n, module federation ready).
 - **Data:** TimescaleDB for historical storage, Apache Ignite for caching.
@@ -16,18 +13,7 @@
 - **Security:** JWT with OpenFeature-ready hooks.
 - **Licensing:** OSS-only dependencies (Docker images `-oss`/Debian and community libraries).
 
-**Italiano:**
-- **Backend:** .NET 8 Aspire con Dapr su gRPC e pub/sub Kafka.
-- **Frontend:** Angular 19 (standalone, i18n, predisposto per module federation).
-- **Dati:** TimescaleDB per lo storico, Apache Ignite per la cache.
-- **Messaging:** Kafka per gli eventi telemetrici.
-- **Realtime:** SignalR e canali di notifica.
-- **Osservabilità:** OpenTelemetry esportato verso Prometheus, Loki, Tempo, Grafana.
-- **Sicurezza:** JWT con integrazione OpenFeature-ready.
-- **Licensing:** Dipendenze solo OSS (immagini Docker `-oss`/Debian e librerie community).
-
-## Quick start / Avvio rapido
-**English:**
+## Quick start
 ```bash
 make build
 make dev
@@ -37,23 +23,10 @@ Orchestrate the full topology with Aspire:
 dotnet run --project src/AppHost/Momentum.AppHost.csproj
 ```
 
-**Italiano:**
-```bash
-make build
-make dev
-```
-Per orchestrare l'intera topologia con Aspire:
-```bash
-dotnet run --project src/AppHost/Momentum.AppHost.csproj
-```
-
 ## Devcontainer
-**English:** The repository ships a ready-to-use [Dev Container](https://containers.dev/) configuration in `.devcontainer/`. It ensures a consistent environment for builds, tests, and security checks. Follow the detailed instructions in [`docs/devcontainer.md`](docs/devcontainer.md).
+The repository ships a ready-to-use [Dev Container](https://containers.dev/) configuration in `.devcontainer/`. It ensures a consistent environment for builds, tests, and security checks. Follow the detailed instructions in [`docs/devcontainer.md`](docs/devcontainer.md).
 
-**Italiano:** Il repository include una configurazione [Dev Container](https://containers.dev/) pronta all'uso in `.devcontainer/`. Garantisce un ambiente coerente per build, test e controlli di sicurezza. Le istruzioni dettagliate sono in [`docs/devcontainer.md`](docs/devcontainer.md).
-
-## Services / Servizi
-**English:**
+## Services
 | Service | Description |
 | --- | --- |
 | identifier | Authentication and license management |
@@ -63,53 +36,23 @@ dotnet run --project src/AppHost/Momentum.AppHost.csproj
 | modular-monolith | Aggregates all backend capabilities via Dapr |
 | web-core | Modular Angular frontend |
 
-**Italiano:**
-| Servizio | Descrizione |
-| --- | --- |
-| identifier | Autenticazione e gestione licenze |
-| streamer | Ingest telemetria da Kafka → Timescale/Ignite |
-| notifier | Invio notifiche multi-canale |
-| web-backend-core | Gateway API + hub SignalR |
-| modular-monolith | Aggrega tutte le capability backend tramite Dapr |
-| web-core | Frontend modulare Angular |
-
-## End-to-end flow / Flusso end-to-end
-**English:**
+## End-to-end flow
 1. A raw event arrives on `telemetry.input` (Kafka).
 2. The streamer transforms it, persists to Timescale, invalidates Ignite cache, and publishes `telemetry.ingested`.
 3. The notifier subscribes to the event, delivers mail/SignalR via web-backend-core.
 4. Web-backend-core broadcasts on the SignalR hub.
 5. Web-core receives the realtime notification and updates the dashboard.
 
-**Italiano:**
-1. Un evento grezzo arriva su `telemetry.input` (Kafka).
-2. Lo streamer lo trasforma, lo persiste su Timescale, invalida la cache Ignite e pubblica `telemetry.ingested`.
-3. Il notifier sottoscrive l'evento, invia mail/SignalR tramite web-backend-core.
-4. Web-backend-core trasmette sull'hub SignalR.
-5. Web-core riceve la notifica realtime e aggiorna la dashboard.
-
-## Useful scripts / Script utili
-**English:**
+## Useful scripts
 - `tools/scripts/generate-sample-data.sh` seeds demo events.
 - `make test` runs .NET and Angular tests (best-effort in CI).
 - `make contracts` produces the contract bundle.
 
-**Italiano:**
-- `tools/scripts/generate-sample-data.sh` genera eventi demo.
-- `make test` esegue test .NET e Angular (best-effort in CI).
-- `make contracts` produce l'archivio dei contratti.
-
-## Deployment / Deploy
-**English:**
+## Deployment
 - `docker compose up` spins up the full environment (infrastructure + services).
 - `src/AppHost` hosts local orchestration with .NET Aspire.
 
-**Italiano:**
-- `docker compose up` avvia l'ambiente completo (infra + servizi).
-- `src/AppHost` gestisce l'orchestrazione locale con .NET Aspire.
-
-## Repository configuration / Configurazione del repository
-**English:**
+## Repository configuration
 - `Directory.Build.props` centralises common .NET build settings (nullable, analyzers, warnings-as-errors).
 - `Directory.Packages.props` manages package versions and floating constraints shared across projects.
 - `NuGet.config` pins internal feeds and enables repeatable restore.
@@ -118,31 +61,12 @@ dotnet run --project src/AppHost/Momentum.AppHost.csproj
 - `docker-compose*.yml` files define local/CI infrastructure for databases, Kafka, and observability.
 - `ReleaseNotes/` collects generated release artefacts per version.
 
-**Italiano:**
-- `Directory.Build.props` centralizza le impostazioni comuni di build .NET (nullable, analyzer, warnings-as-errors).
-- `Directory.Packages.props` gestisce le versioni dei pacchetti e i vincoli condivisi fra i progetti.
-- `NuGet.config` blocca i feed interni e abilita restore ripetibili.
-- `global.json` vincola la versione di .NET SDK usata da CI e devcontainer.
-- `Makefile` coordina build, test, lint, contratti e automazioni di release.
-- I file `docker-compose*.yml` definiscono l'infrastruttura locale/CI per database, Kafka e osservabilità.
-- `ReleaseNotes/` raccoglie gli artefatti di release generati per versione.
-
-## Documentation / Documentazione
-**English:**
-- [`architecture-overview.md`](architecture-overview.md) describes the system using the C4 model.
-- [`docs/`](docs/) contains policies, guidelines, ADRs, and operational manuals.
+## Documentation
+- [`architecture-overview.md`](architecture-overview.md) describes the system using the C4 model and highlights how the modular monolith encapsulates domain capabilities behind Dapr endpoints.
+- [`docs/06-Modular-Architecture-Guidelines.md`](docs/06-Modular-Architecture-Guidelines.md) acts as the developer playbook for modular monolith extensions and module onboarding.
+- [`docs/02-Coding-Guidelines.md`](docs/02-Coding-Guidelines.md) and the remaining policies under `docs/` cover day-to-day engineering practices.
 - [`contracts/`](contracts/) holds proto/OpenAPI/event schemas.
 
-**Italiano:**
-- [`architecture-overview.md`](architecture-overview.md) descrive il sistema con il modello C4.
-- [`docs/`](docs/) ospita policy, linee guida, ADR e manuali operativi.
-- [`contracts/`](contracts/) contiene i contratti proto/OpenAPI/eventi.
-
-## Process automation / Automazioni di processo
-**English:**
+## Process automation
 - **Ensure issue linking:** workflow that enforces issue references in commits. When missing, it opens a summary ticket and updates the pull request description.
 - **Generate release notes:** manual workflow that creates release note files for the repository and modules, stored under `ReleaseNotes/` with the provided version number.
-
-**Italiano:**
-- **Ensure issue linking:** workflow che impone la presenza del riferimento alle issue nei commit. In mancanza, apre un ticket riassuntivo e aggiorna la descrizione della pull request.
-- **Generate release notes:** workflow manuale che crea i file di release note per repository e moduli, salvati in `ReleaseNotes/` con il numero di versione fornito.

--- a/architecture-overview.md
+++ b/architecture-overview.md
@@ -1,70 +1,33 @@
-# Architecture Overview (C4) / Panoramica Architetturale (C4)
+# Architecture Overview (C4)
 
-## C1 – System Context / Contesto di Sistema
-**English:**
+## C1 – System Context
 - **Momentum Platform** ingests telemetry, manages identities, and broadcasts notifications.
 - External actors: Operators (web UI), sensor producers (Kafka), email/SMS providers, observability stack.
 
-**Italiano:**
-- **Momentum Platform** raccoglie telemetria, gestisce identità e pubblica notifiche.
-- Attori esterni: Operatori (web UI), produttori di sensori (Kafka), provider email/SMS, stack di osservabilità.
-
-## C2 – Container Diagram / Diagramma dei Container
-**English:**
+## C2 – Container Diagram
 - **web-core (Angular):** shell consuming SignalR and federated modules.
 - **web-backend-core (.NET):** API gateway + SignalR hub + OpenFeature integration.
-- **modular-monolith (.NET):** Unified façade invoking all services via Dapr.
+- **modular-monolith (.NET):** Unified façade invoking all services via Dapr and acting as the reference architecture for modular monolith deployments.
 - **identifier service:** gRPC auth, JWT minting.
 - **streamer service:** Kafka consumer, TimescaleDB persistence, Ignite cache.
 - **notifier service:** Subscribes to `telemetry.ingested`, dispatches email/SignalR.
 - **Infrastructure:** Kafka, TimescaleDB, Ignite, Prometheus, Loki, Tempo, Grafana, Dapr sidecars.
 
-**Italiano:**
-- **web-core (Angular):** shell che consuma SignalR e moduli federati.
-- **web-backend-core (.NET):** API gateway + hub SignalR + integrazione OpenFeature.
-- **modular-monolith (.NET):** Facciata unificata che invoca tutti i servizi tramite Dapr.
-- **identifier service:** autenticazione gRPC, emissione JWT.
-- **streamer service:** consumer Kafka, persistenza TimescaleDB, cache Ignite.
-- **notifier service:** si sottoscrive a `telemetry.ingested`, inoltra email/SignalR.
-- **Infrastruttura:** Kafka, TimescaleDB, Ignite, Prometheus, Loki, Tempo, Grafana, sidecar Dapr.
-
-## C3 – Component Diagram (web-backend-core) / Diagramma dei Componenti (web-backend-core)
-**English:**
+## C3 – Component Diagram (web-backend-core)
 - Controllers orchestrate requests.
 - `NotificationOrchestrator` coordinates broadcasts.
 - `SignalRNotificationBroadcaster` publishes to the hub.
 - `NotificationHub` exposes the realtime channel.
 - `DaprClient` handles module invocations.
 
-**Italiano:**
-- I controller orchestrano le richieste.
-- `NotificationOrchestrator` coordina i broadcast.
-- `SignalRNotificationBroadcaster` pubblica sull'hub.
-- `NotificationHub` espone il canale realtime.
-- `DaprClient` gestisce le invocazioni ai moduli.
-
-## C4 – Code/Module View / Vista Code/Modulo
-**English:**
+## C4 – Code/Module View
 - Clean architecture layers per service (`Domain` → `Application` → `Infrastructure` → `Api`).
 - Versioned contracts in `/contracts`.
 - Tests in `/tests`.
 - Module federation powering the modular frontend.
 
-**Italiano:**
-- Strati clean architecture per servizio (`Domain` → `Application` → `Infrastructure` → `Api`).
-- Contratti versionati in `/contracts`.
-- Test in `/tests`.
-- Module federation a supporto del frontend modulare.
-
-## Quality Attributes / Attributi di Qualità
-**English:**
+## Quality Attributes
 - **Resilience:** Dapr retries, Kafka buffering, Ignite caching.
 - **Observability:** OpenTelemetry/Prometheus, logs in Loki, traces in Tempo.
 - **Security:** JWT, roles, feature flags via OpenFeature.
 - **Evolvability:** Stable contracts, bounded contexts per module, plug-in modules.
-
-**Italiano:**
-- **Resilienza:** retry Dapr, buffering Kafka, caching Ignite.
-- **Osservabilità:** OpenTelemetry/Prometheus, log su Loki, trace su Tempo.
-- **Sicurezza:** JWT, ruoli, feature flag con OpenFeature.
-- **Evolvibilità:** Contratti stabili, bounded context per modulo, moduli plug-in.

--- a/docs/01-Architecture
+++ b/docs/01-Architecture
@@ -1,7 +1,3 @@
-# Architecture Index / Indice Architetturale
+# Architecture Index
 
-## English
-Refer to [`../01-Architecture-Policy.md`](../01-Architecture-Policy.md) and [`../../architecture-overview.md`](../../architecture-overview.md) for the C4 model and architectural principles.
-
-## Italiano
-Consulta [`../01-Architecture-Policy.md`](../01-Architecture-Policy.md) e [`../../architecture-overview.md`](../../architecture-overview.md) per il modello C4 e i principi architetturali.
+Refer to [`../01-Architecture-Policy.md`](../01-Architecture-Policy.md) and [`../../architecture-overview.md`](../../architecture-overview.md) for the C4 model and architectural principles. For modular monolith specifics, pair these documents with the [Modular Architecture Guidelines](../06-Modular-Architecture-Guidelines.md).

--- a/docs/01-Architecture-Policy.md
+++ b/docs/01-Architecture-Policy.md
@@ -1,14 +1,8 @@
-# Architecture Policy / Politica Architetturale
+# Architecture Policy
 
-## Principles / Principi
-**English:**
+## Principles
 - Each bounded context follows DDD with Clean Architecture layering.
 - External contracts (gRPC, OpenAPI, event schema) live in `/contracts` and are published as CI artefacts.
 - Aspire and Dapr are the default for local orchestration and service invocation.
 - Infrastructure dependencies (Kafka, Timescale, Ignite) are managed as code (docker compose / Bicep TBD).
-
-**Italiano:**
-- Ogni bounded context segue DDD con layering Clean Architecture.
-- I contratti esterni (gRPC, OpenAPI, event schema) risiedono in `/contracts` e vengono pubblicati come artefatti CI.
-- Aspire e Dapr sono il default per l'orchestrazione locale e le chiamate fra servizi.
-- Le dipendenze infrastrutturali (Kafka, Timescale, Ignite) sono gestite come codice (docker compose / Bicep da definire).
+- The modular monolith provides the canonical integration surface; distributed services must preserve the same contracts and follow the [Modular Architecture Guidelines](06-Modular-Architecture-Guidelines.md).

--- a/docs/02-Coding-Guidelines.md
+++ b/docs/02-Coding-Guidelines.md
@@ -1,27 +1,14 @@
-# Coding Guidelines / Linee Guida di Sviluppo
+# Coding Guidelines
 
-## Core practices / Pratiche di base
-**English:**
+## Core practices
 - Target C# 12 on `net8.0` with nullable enabled.
 - Layering: `Api` depends on `Application` → `Domain`; `Infrastructure` implements ports.
 - Input validation relies on records and light CQRS handlers.
 - Frontend uses Angular standalone components, typed SignalR wrappers, and RxJS streams.
 - Every feature requires unit tests plus minimal integration coverage.
+- When building modules for the modular monolith, align abstractions with the domain boundaries defined in the [Modular Architecture Guidelines](06-Modular-Architecture-Guidelines.md) and expose contracts through `/contracts`.
 
-**Italiano:**
-- Target C# 12 su `net8.0` con nullable abilitato.
-- Layering: `Api` dipende da `Application` → `Domain`; `Infrastructure` implementa le porte.
-- La validazione input utilizza record e handler CQRS leggeri.
-- Il frontend adotta componenti standalone Angular, wrapper SignalR tipizzati e stream RxJS.
-- Ogni feature richiede test unitari più una copertura di integrazione minima.
-
-## Commit & issue hygiene / Buone pratiche per commit e issue
-**English:**
+## Commit & issue hygiene
 - Each commit subject must reference the primary issue (`#123`).
 - Pull requests must keep the _Fixes_ section updated with covered issues. The _Ensure issue linking_ workflow updates the description when it detects unlinked commits and creates missing issues via LLM.
 - Before merging, tidy commits and squash only when necessary to preserve traceability with generated issues.
-
-**Italiano:**
-- Ogni commit deve riportare nel subject il riferimento alla issue principale (`#123`).
-- Le pull request devono mantenere aggiornata la sezione _Fixes_ con le issue coperte. Il workflow _Ensure issue linking_ aggiorna la descrizione quando rileva commit non collegati e crea le issue mancanti tramite LLM.
-- Prima del merge ripulisci i commit e fai squash solo se necessario, preservando la tracciabilità con le issue generate.

--- a/docs/03-Versioning-Policy.md
+++ b/docs/03-Versioning-Policy.md
@@ -1,51 +1,25 @@
-# Versioning Policy / Politica di Versionamento
+# Versioning Policy
 
-## SemVer rules / Regole SemVer
-**English:**
+## SemVer rules
 - Services and frontend follow Semantic Versioning.
-- gRPC/OpenAPI contracts versioned through `vX` namespaces/routes.
+- gRPC/OpenAPI contracts are versioned through `vX` namespaces/routes.
 - Event schemas carry incremental `$id` identifiers.
 - Docker tags use `major.minor.patch` plus `latest` for demo environments.
+- Modular monolith packages track the same semantic versions as their distributed counterparts to guarantee compatibility.
 
-**Italiano:**
-- Servizi e frontend adottano il Semantic Versioning.
-- I contratti gRPC/OpenAPI sono versionati tramite namespace/route `vX`.
-- Gli event schema includono identificativi `$id` incrementali.
-- I tag Docker usano `major.minor.patch` e `latest` per gli ambienti demo.
-
-## Merge flow to `main` / Flusso di merge verso `main`
-**English:**
+## Merge flow to `main`
 1. Each task lives on a feature branch derived from `main` and linked to a GitHub issue.
 2. Feature branches merge through pull requests; merging into `main` happens via GitHub merge commits once approvals and checks pass.
 3. Before merging, the _Ensure issue linking_ workflow verifies that every commit references an issue (`#<number>`). If missing, it creates an issue summarising the changes and updates the PR description.
 4. After merge, `main` always reflects a release-ready state. Version numbers are bumped and tagged alongside release note generation.
 
-**Italiano:**
-1. Ogni attività vive su un branch feature derivato da `main` e collegato a una issue GitHub.
-2. I branch feature vengono integrati tramite pull request; il merge su `main` avviene con merge commit di GitHub dopo approvazioni e controlli positivi.
-3. Prima del merge il workflow _Ensure issue linking_ verifica che ogni commit referenzi una issue (`#<numero>`). Se manca, crea una issue con il riassunto delle modifiche e aggiorna la descrizione della PR.
-4. Dopo il merge `main` rappresenta sempre uno stato pronto alla release. Il numero di versione viene incrementato e taggato insieme alla generazione delle release note.
-
-## Automated issue & commit management / Gestione automatica di issue e commit
-**English:**
+## Automated issue & commit management
 - Every commit message must include an issue reference (`#123`).
 - The script `tools/issue_management/ensure_issue_links.py` runs in PR pipelines to enforce references. With `GITHUB_TOKEN` and `OPENAI_API_KEY` configured, it can create missing issues via LLM and update the PR body with `Fixes #<number>`.
 - The script output reports the performed actions and blocks the check until every commit is linked.
 
-**Italiano:**
-- Ogni commit deve includere nel messaggio il riferimento a una issue (`#123`).
-- Lo script `tools/issue_management/ensure_issue_links.py` gira nelle pipeline delle PR per garantire la presenza dei riferimenti. Con `GITHUB_TOKEN` e `OPENAI_API_KEY` configurati crea le issue mancanti via LLM e aggiorna il corpo della PR con `Fixes #<numero>`.
-- L'output dello script riporta le azioni svolte e rende il controllo bloccante finché tutti i commit non sono collegati.
-
 ## Release notes
-**English:**
 - The manual _Generate release notes_ workflow builds release files from commits between a base ref and the target version.
 - Files land in `ReleaseNotes/` and `modules/<module-name>/ReleaseNotes/` for each affected module.
 - Each file lists linked issues and included commits to provide full visibility.
 - During the workflow execution, a commit on `main` is created with the generated notes using the message `chore: add release notes for <version>`.
-
-**Italiano:**
-- Il workflow manuale _Generate release notes_ crea i file a partire dai commit tra un riferimento di base e la versione da rilasciare.
-- I file vengono salvati in `ReleaseNotes/` e in `modules/<nome-modulo>/ReleaseNotes/` per ogni modulo interessato.
-- Ogni file elenca le issue collegate e i commit inclusi per offrire piena visibilità.
-- Durante l'esecuzione del workflow viene creato un commit su `main` con le note generate e il messaggio `chore: add release notes for <version>`.

--- a/docs/04-Security-Policy.md
+++ b/docs/04-Security-Policy.md
@@ -1,16 +1,9 @@
-# Security Policy / Politica di Sicurezza
+# Security Policy
 
-## Controls / Controlli
-**English:**
+## Controls
 - JWT tokens are signed with a rotatable key stored in Key Vault (placeholder implementation).
 - OpenFeature drives feature flags and licensing via a Dapr binding provider.
 - Timescale and Ignite access follows the principle of least privilege.
 - gRPC plus HTTPS are mandatory in production environments.
 - Secrets must never live in the repository; use CI/CD variables instead.
-
-**Italiano:**
-- I token JWT sono firmati con una chiave rotabile memorizzata in Key Vault (implementazione placeholder).
-- OpenFeature gestisce feature flag e licensing tramite un provider Dapr binding.
-- L'accesso a Timescale e Ignite segue il principio del minimo privilegio.
-- gRPC e HTTPS sono obbligatori negli ambienti produttivi.
-- I secret non devono mai essere nel repository; usa variabili di CI/CD.
+- Modular monolith deployments inherit the same security controls as the distributed topology to maintain parity across environments.

--- a/docs/05-Testing-Policy.md
+++ b/docs/05-Testing-Policy.md
@@ -1,16 +1,8 @@
-# Testing Policy / Politica di Test
+# Testing Policy
 
-## Coverage pillars / Pilastri di copertura
-**English:**
+## Coverage pillars
 - **Unit:** xUnit for .NET, Jasmine for Angular.
 - **Integration:** gRPC/HTTP tests with Testcontainers (TODO) plus Playwright e2e.
 - **Contract:** schema verification via `buf`/`spectral` (pipeline step TBD).
 - **E2E:** Playwright orchestrated against the docker compose profile.
-- **Coverage goal:** minimum 70% for critical domains.
-
-**Italiano:**
-- **Unit:** xUnit per .NET, Jasmine per Angular.
-- **Integration:** test gRPC/HTTP con Testcontainers (TODO) e Playwright e2e.
-- **Contract:** verifica schema tramite `buf`/`spectral` (step di pipeline da definire).
-- **E2E:** Playwright orchestrato contro il profilo docker compose.
-- **Obiettivo copertura:** minimo 70% per i domini critici.
+- **Coverage goal:** minimum 70% for critical domains, including modules delivered through the modular monolith façade.

--- a/docs/06-Modular-Architecture-Guidelines.md
+++ b/docs/06-Modular-Architecture-Guidelines.md
@@ -1,14 +1,8 @@
-# Modular Architecture Guidelines / Linee Guida per l'Architettura Modulare
+# Modular Architecture Guidelines
 
-## Contracts & boundaries / Contratti e confini
-**English:**
+## Contracts & boundaries
 - Each module exposes independent contracts in `/contracts/<module>`.
 - Shared use cases flow through the web-backend-core orchestrator via Dapr gRPC.
 - Module federation lets every micro-frontend expose its entry point as a remote.
 - Backend plug-ins register through Dapr service discovery.
-
-**Italiano:**
-- Ogni modulo espone contratti indipendenti in `/contracts/<module>`.
-- I casi d'uso condivisi passano dall'orchestratore web-backend-core tramite gRPC Dapr.
-- La module federation consente a ogni micro-frontend di esporre il proprio entry point come remote.
-- I plug-in backend si registrano tramite il service discovery di Dapr.
+- The modular monolith hosts modules behind a unified façade; when extracting services, keep the same contracts to maintain backwards compatibility.

--- a/docs/07-Observability-Guidelines.md
+++ b/docs/07-Observability-Guidelines.md
@@ -1,16 +1,9 @@
-# Observability Guidelines / Linee Guida per l'Osservabilità
+# Observability Guidelines
 
-## Telemetry baseline / Baseline di telemetria
-**English:**
+## Telemetry baseline
 - OpenTelemetry SDK is configured in all services for metrics and traces.
 - Default export path: OTLP → Tempo, Prometheus scrape, Loki for logs.
 - Every service exposes `/healthz` and `/metrics` endpoints.
 - Grafana dashboards are versioned under `observability/dashboards` (TODO).
 - Observability stack relies exclusively on OSS components (Prometheus, Loki, Tempo, Grafana OSS).
-
-**Italiano:**
-- L'SDK OpenTelemetry è configurato in tutti i servizi per metriche e trace.
-- Flusso di esportazione predefinito: OTLP → Tempo, Prometheus per lo scrape, Loki per i log.
-- Ogni servizio espone gli endpoint `/healthz` e `/metrics`.
-- Le dashboard Grafana sono versionate in `observability/dashboards` (TODO).
-- Lo stack di osservabilità si basa esclusivamente su componenti OSS (Prometheus, Loki, Tempo, Grafana OSS).
+- Modular monolith deployments emit the same telemetry envelopes to ensure consistent dashboards regardless of runtime topology.

--- a/docs/08-Data-Guidelines.md
+++ b/docs/08-Data-Guidelines.md
@@ -1,16 +1,9 @@
-# Data Guidelines / Linee Guida sui Dati
+# Data Guidelines
 
-## Storage strategy / Strategia di storage
-**English:**
+## Storage strategy
 - Timescale schema `telemetry_events` managed through migrations (TODO EF Core migrations).
 - Ignite powers realtime cache and in-memory analytics.
 - Timescale retention set to 365 days with compression enabled.
 - Sensitive data encrypted at rest and in transit.
 - Only OSS database/cache components (TimescaleDB OSS, Apache Ignite OSS) to honour licensing requirements.
-
-**Italiano:**
-- Lo schema Timescale `telemetry_events` è gestito tramite migrazioni (TODO EF Core migrations).
-- Ignite alimenta la cache realtime e le analisi in-memory.
-- La retention di Timescale è impostata a 365 giorni con compressione attiva.
-- I dati sensibili sono cifrati at-rest e in-transit.
-- Sono utilizzati solo componenti database/cache OSS (TimescaleDB OSS, Apache Ignite OSS) per rispettare i requisiti di licenza.
+- Modular monolith modules must treat the shared data stores as authoritative sources and avoid duplicating persistence when extracted into standalone services.

--- a/docs/adr/0001.md
+++ b/docs/adr/0001.md
@@ -1,27 +1,15 @@
-# ADR 0001: Use .NET Aspire with Dapr for local orchestration / Utilizzo di .NET Aspire con Dapr per l'orchestrazione locale
+# ADR 0001: Use .NET Aspire with Dapr for local orchestration
 
-## Status / Stato
-**English:** Accepted
+## Status
+Accepted
 
-**Italiano:** Accettata
+## Context
+Multiple services need local orchestration with Dapr sidecars and dependencies such as Kafka and Timescale while maintaining parity with the modular monolith runtime.
 
-## Context / Contesto
-**English:** Multiple services need local orchestration with Dapr sidecars and dependencies such as Kafka and Timescale.
+## Decision
+Adopt the .NET Aspire AppHost to define local infrastructure and Dapr sidecars, keeping the monolith and microservice topologies consistent.
 
-**Italiano:** Più servizi richiedono orchestrazione locale con sidecar Dapr e dipendenze come Kafka e Timescale.
-
-## Decision / Decisione
-**English:** Adopt the .NET Aspire AppHost to define local infrastructure and Dapr sidecars, keeping the monolith and microservice topologies consistent.
-
-**Italiano:** Adottare .NET Aspire AppHost per definire l'infrastruttura locale e i sidecar Dapr, mantenendo coerenti le topologie monolite e microservizi.
-
-## Consequences / Conseguenze
-**English:**
+## Consequences
 - Simplified local startup via `dotnet run` on the AppHost.
 - Ability to define infrastructure dependencies as code.
 - Requires preview SDKs while Aspire remains in preview.
-
-**Italiano:**
-- Avvio locale semplificato tramite `dotnet run` sull'AppHost.
-- Possibilità di definire le dipendenze infrastrutturali come codice.
-- Richiede SDK in preview finché Aspire resta in preview.

--- a/docs/adr/0002.md
+++ b/docs/adr/0002.md
@@ -1,27 +1,15 @@
-# ADR 0002: Internal communications via gRPC + Dapr / Comunicazioni interne via gRPC + Dapr
+# ADR 0002: Internal communications via gRPC + Dapr
 
-## Status / Stato
-**English:** Accepted
+## Status
+Accepted
 
-**Italiano:** Accettata
+## Context
+The platform must stay consistent between modular monolith and microservice modes while minimising coupling.
 
-## Context / Contesto
-**English:** The platform must stay consistent between modular monolith and microservice modes while minimising coupling.
+## Decision
+Use gRPC as the synchronous protocol with Dapr service invocation. `.proto` contracts are versioned and reusable.
 
-**Italiano:** La piattaforma deve rimanere consistente tra modalità monolite e microservizi riducendo il coupling.
-
-## Decision / Decisione
-**English:** Use gRPC as the synchronous protocol with Dapr service invocation. `.proto` contracts are versioned and reusable.
-
-**Italiano:** Usare gRPC come protocollo sincrono con invocazione servizi Dapr. I contratti `.proto` sono versionati e riutilizzabili.
-
-## Consequences / Conseguenze
-**English:**
+## Consequences
 - Strongly typed contracts reusable by clients and servers.
 - Requires managing generated packages for frontend/edge consumers.
 - Adds complexity for environments without gRPC support → REST gateway fallback.
-
-**Italiano:**
-- Contratti fortemente tipizzati riutilizzabili lato client/server.
-- Richiede la gestione dei pacchetti generati per frontend/edge.
-- Aggiunge complessità negli ambienti che non supportano gRPC → fallback REST via gateway.

--- a/docs/adr/0003.md
+++ b/docs/adr/0003.md
@@ -1,27 +1,15 @@
-# ADR 0003: Kafka as event-driven backbone / Kafka come backbone event-driven
+# ADR 0003: Kafka as event-driven backbone
 
-## Status / Stato
-**English:** Accepted
+## Status
+Accepted
 
-**Italiano:** Accettata
+## Context
+We need a highly scalable bus compatible with Dapr to orchestrate telemetry events across the modular monolith and future microservices.
 
-## Context / Contesto
-**English:** We need a highly scalable bus compatible with Dapr to orchestrate telemetry events.
+## Decision
+Adopt Kafka with Dapr pub/sub. Main topics: `telemetry.input`, `telemetry.ingested`.
 
-**Italiano:** Serve un bus altamente scalabile e compatibile con Dapr per orchestrare gli eventi di telemetria.
-
-## Decision / Decisione
-**English:** Adopt Kafka with Dapr pub/sub. Main topics: `telemetry.input`, `telemetry.ingested`.
-
-**Italiano:** Adottare Kafka con pub/sub Dapr. Topic principali: `telemetry.input`, `telemetry.ingested`.
-
-## Consequences / Conseguenze
-**English:**
+## Consequences
 - Native Dapr support and a rich tooling ecosystem.
 - Requires managed cluster operations in production.
 - Needs a schema registry for evolution (TODO).
-
-**Italiano:**
-- Supporto nativo Dapr e tooling ricco.
-- Richiede la gestione del cluster in produzione.
-- Necessita di uno schema registry per l'evoluzione (TODO).

--- a/docs/adr/0004.md
+++ b/docs/adr/0004.md
@@ -1,25 +1,14 @@
-# ADR 0004: SignalR for realtime notifications / SignalR per notifiche realtime
+# ADR 0004: SignalR for realtime notifications
 
-## Status / Stato
-**English:** Accepted
+## Status
+Accepted
 
-**Italiano:** Accettata
+## Context
+Operators must receive real-time updates without relying on polling.
 
-## Context / Contesto
-**English:** Operators must receive real-time updates without relying on polling.
+## Decision
+Use SignalR as the realtime channel exposed by web-backend-core, integrated with the notifier service.
 
-**Italiano:** Gli operatori devono ricevere aggiornamenti in tempo reale senza ricorrere al polling.
-
-## Decision / Decisione
-**English:** Use SignalR as the realtime channel exposed by web-backend-core, integrated with the notifier service.
-
-**Italiano:** Usare SignalR come canale realtime esposto da web-backend-core, integrato con il servizio notifier.
-
-## Consequences / Conseguenze
-**English:**
+## Consequences
 - Angular client integrates via `@microsoft/signalr`.
 - Requires sticky sessions or a backplane for horizontal scale (Azure SignalR / Redis).
-
-**Italiano:**
-- Il client Angular si integra tramite `@microsoft/signalr`.
-- Richiede sticky session o un backplane per la scalabilità orizzontale (Azure SignalR / Redis).

--- a/docs/adr/0005.md
+++ b/docs/adr/0005.md
@@ -1,27 +1,15 @@
-# ADR 0005: TimescaleDB + Apache Ignite for hybrid storage / TimescaleDB + Apache Ignite per storage ibrido
+# ADR 0005: TimescaleDB + Apache Ignite for hybrid storage
 
-## Status / Stato
-**English:** Accepted
+## Status
+Accepted
 
-**Italiano:** Accettata
+## Context
+The platform needs both historical time-series persistence and low-latency realtime responses for modular monolith scenarios and extracted services.
 
-## Context / Contesto
-**English:** The platform needs both historical time-series persistence and low-latency realtime responses.
+## Decision
+Use TimescaleDB for historical storage and Apache Ignite as the shared data grid/cache.
 
-**Italiano:** La piattaforma richiede sia persistenza storica time-series sia risposte realtime a bassa latenza.
-
-## Decision / Decisione
-**English:** Use TimescaleDB for historical storage and Apache Ignite as the shared data grid/cache.
-
-**Italiano:** Usare TimescaleDB per lo storage storico e Apache Ignite come data grid/cache condivisa.
-
-## Consequences / Conseguenze
-**English:**
+## Consequences
 - Optimised analytical queries on Timescale.
 - Ignite provides near-cache and in-memory computations.
 - Requires dedicated orchestration and monitoring.
-
-**Italiano:**
-- Query analitiche ottimizzate su Timescale.
-- Ignite offre near-cache e calcoli in-memory.
-- Richiede orchestrazione e monitoraggio dedicati.

--- a/docs/devcontainer.md
+++ b/docs/devcontainer.md
@@ -1,27 +1,16 @@
-# Devcontainer Momentum / Devcontainer di Momentum
+# Devcontainer Momentum
 
-## Purpose / Scopo
-**English:** The Dev Container provides a reproducible environment for day-to-day development on the Momentum platform.
+## Purpose
+The Dev Container provides a reproducible environment for day-to-day development on the Momentum platform.
 
-**Italiano:** Il Dev Container offre un ambiente riproducibile per lo sviluppo quotidiano della piattaforma Momentum.
-
-## Main contents / Contenuti principali
-**English:**
+## Main contents
 - **Custom Dockerfile** based on `mcr.microsoft.com/devcontainers/dotnet` with essential tooling (`make`, `jq`, `git`, `curl`) for builds, tests, and security analysis.
 - **Node 20 feature** to support Angular 19 and npm scripts.
 - **Docker-in-Docker support** to run `docker compose` from inside the development container.
 - **Post-create script** restoring .NET/Angular packages and preparing Playwright for end-to-end tests.
 - **VS Code tasks** for `make build`, `make test`, dependency audits (`dotnet list ...`, `npm audit`), and Angular linting.
 
-**Italiano:**
-- **Dockerfile personalizzato** basato su `mcr.microsoft.com/devcontainers/dotnet` con tool essenziali (`make`, `jq`, `git`, `curl`) per build, test e analisi di sicurezza.
-- **Feature Node 20** per supportare Angular 19 e gli script npm.
-- **Supporto Docker-in-Docker** per eseguire `docker compose` dall'interno del container di sviluppo.
-- **Script post-create** che ripristina i pacchetti .NET/Angular e prepara Playwright per i test end-to-end.
-- **Task VS Code** per `make build`, `make test`, audit dipendenze (`dotnet list ...`, `npm audit`) e linting Angular.
-
-## Usage / Utilizzo
-**English:**
+## Usage
 1. Install the [Dev Containers](https://marketplace.visualstudio.com/items?itemName=ms-vscode-remote.remote-containers) extension in VS Code.
 2. Open the repository folder and choose `Dev Containers: Reopen in Container`.
 3. Wait for the bootstrap script to finish. You will have:
@@ -29,32 +18,13 @@
    - Playwright ready for end-to-end tests (`make e2e`);
    - ports 4200/5000/5001/9090 forwarded to the host for frontend, backend, and observability.
 4. Use the available tasks (`Terminal > Run Task...`) to build, test, or run security scans.
+5. For modular monolith development, the container exposes all prerequisites (Dapr CLI, Aspire tooling, Node.js) required by the [Modular Architecture Guidelines](06-Modular-Architecture-Guidelines.md).
 
-**Italiano:**
-1. Installa l'estensione [Dev Containers](https://marketplace.visualstudio.com/items?itemName=ms-vscode-remote.remote-containers) in VS Code.
-2. Apri la cartella del repository e scegli `Dev Containers: Reopen in Container`.
-3. Attendi il completamento dello script di bootstrap. Otterrai:
-   - dipendenze .NET e npm ripristinate;
-   - Playwright pronto per i test end-to-end (`make e2e`);
-   - porte 4200/5000/5001/9090 inoltrate verso l'host per frontend, backend e osservabilità.
-4. Utilizza i task disponibili (`Terminal > Run Task...`) per build, test o security scan.
-
-## Helper scripts / Script di supporto
-**English:**
+## Helper scripts
 - `.devcontainer/scripts/post-create.sh` – initial provisioning (restore packages, set up Playwright).
 - `.devcontainer/scripts/post-start.sh` – normalises HTTPS certificate permissions and prints the main commands.
 - `.devcontainer/scripts/setup-https-certs.sh` – idempotently creates development HTTPS certificates when missing.
 
-**Italiano:**
-- `.devcontainer/scripts/post-create.sh` – provisioning iniziale (restore pacchetti, setup Playwright).
-- `.devcontainer/scripts/post-start.sh` – normalizza i permessi dei certificati HTTPS e mostra i comandi principali.
-- `.devcontainer/scripts/setup-https-certs.sh` – crea in modo idempotente i certificati HTTPS di sviluppo se mancanti.
-
-## Notes / Note
-**English:**
+## Notes
 - Development HTTPS certificates are mounted from the host into `/home/vscode/.aspnet/https` to maintain ASP.NET compatibility. On Windows the `%USERPROFILE%\.aspnet\https` folder is also mounted and exposed inside the container.
 - To update Playwright or install additional browsers run `npx playwright install --with-deps` inside the container.
-
-**Italiano:**
-- I certificati HTTPS di sviluppo sono montati dalla macchina host in `/home/vscode/.aspnet/https` per mantenere la compatibilità con ASP.NET. Su Windows viene montata anche la cartella `%USERPROFILE%\.aspnet\https` e resa disponibile nel container.
-- Per aggiornare Playwright o installare browser aggiuntivi esegui `npx playwright install --with-deps` all'interno del container.

--- a/docs/release-process.md
+++ b/docs/release-process.md
@@ -1,23 +1,14 @@
-# Automated Release Flow / Flusso di Rilascio Automatizzato
+# Automated Release Flow
 
-## Overview / Panoramica
-**English:** This document describes how the `Release automation` GitHub Actions workflow prepares a Momentum release.
+## Overview
+This document describes how the `Release automation` GitHub Actions workflow prepares a Momentum release.
 
-**Italiano:** Questo documento descrive come il workflow GitHub Actions `Release automation` prepara una release di Momentum.
-
-## Commit conventions / Convenzioni sui commit
-**English:**
+## Commit conventions
 - The repository follows [Conventional Commits](https://www.conventionalcommits.org/).
 - Relevant types for version calculation: `feat:` → **minor**, `fix:`/`perf:`/`refactor:` → **patch**, commits with `BREAKING CHANGE` or `!` → **major**.
 - The workflow runs `commitlint` on every pull request targeting `main`; keep commits compliant to avoid validation failures.
 
-**Italiano:**
-- Il repository utilizza le [Conventional Commits](https://www.conventionalcommits.org/).
-- Tipologie rilevanti per il calcolo versione: `feat:` → **minor**, `fix:`/`perf:`/`refactor:` → **patch**, commit con `BREAKING CHANGE` o `!` → **major**.
-- Il workflow esegue `commitlint` su ogni pull request verso `main`; mantieni i commit conformi per evitare errori di validazione.
-
-## Version calculation / Calcolo della versione
-**English:**
+## Version calculation
 - `tools/release_notes/ci_release.py plan` inspects commits between the latest `v*` tag and the PR head, computes `nextVersion`, and opens/updates a `release/v<nextVersion>` PR.
 - Adjust the bump by: (1) applying a PR label (`release:major|minor|patch`); or (2) adding `.release-override.yml` with optional fields:
   ```yaml
@@ -28,69 +19,34 @@
     - chore
   ```
 - If a PR only contains documentation or `chore` commits the release is skipped unless `allowDocsOnlyRelease: true` is set.
+- Modular monolith changes follow the same workflow as distributed services to guarantee aligned versioning.
 
-**Italiano:**
-- `tools/release_notes/ci_release.py plan` analizza i commit tra l'ultimo tag `v*` e la testa della PR, calcola `nextVersion` e apre/aggiorna una PR `release/v<nextVersion>`.
-- Puoi modificare il bump: (1) applicando una label alla PR (`release:major|minor|patch`); oppure (2) aggiungendo `.release-override.yml` con i campi opzionali riportati sopra.
-- Se la PR contiene solo commit di documentazione o `chore`, la release viene saltata a meno che `allowDocsOnlyRelease: true` non sia impostato.
-
-## Automatic issue creation / Creazione automatica delle issue
-**English:**
+## Automatic issue creation
 - To preserve traceability the workflow runs `tools/issue_management/ensure_issue_links.py` on every internal PR.
 - When a commit lacks issue references, the script opens a new issue (`feature`, `bug`, or `tech-debt`) and updates the PR body with `Fixes #<id>`.
 - For forks the script operates in dry-run mode and performs no write operations.
 
-**Italiano:**
-- Per mantenere la tracciabilità il workflow esegue `tools/issue_management/ensure_issue_links.py` su ogni PR interna.
-- Quando un commit non contiene riferimenti a issue, lo script apre una nuova issue (`feature`, `bug` o `tech-debt`) e aggiorna il corpo della PR con `Fixes #<id>`.
-- Sui fork lo script lavora in modalità dry-run senza effettuare scritture.
-
 ## Release notes
-**English:**
 - During planning the workflow generates `ReleaseNotes/<version>.md` from `.github/release_notes.hbs`, grouping entries under Breaking Changes, Features, Fixes, Performance, Refactor, Docs, and Chore.
 - A PR comment shows the preview along with the pre-merge checklist (Tests, Lint, Build, Security scan).
 
-**Italiano:**
-- In fase di pianificazione viene generato `ReleaseNotes/<version>.md` usando `.github/release_notes.hbs`, con categorie Breaking Changes, Features, Fixes, Performance, Refactor, Docs e Chore.
-- Un commento sulla PR mostra la preview insieme alla checklist pre-merge (Test, Lint, Build, Security scan).
+## Release PR management
+If the PR is not from a fork, the workflow creates or updates `release/v<version>` → `main` with the release notes file. It must follow the protected-branch merge rules.
 
-## Release PR management / Gestione della PR di release
-**English:** If the PR is not from a fork, the workflow creates or updates `release/v<version>` → `main` with the release notes file. It must follow the protected-branch merge rules.
-
-**Italiano:** Se la PR non proviene da un fork, il workflow crea o aggiorna `release/v<version>` → `main` con il file di release notes. Deve rispettare le regole di merge del branch protetto.
-
-## Branch workflows / Workflow sui branch
-**English:**
+## Branch workflows
 - **PR to main:** version planning, release notes generation, release branch sync, missing issue creation, PR labelling, preview publication.
 - **Push to `release/v*`:** validates that release notes stay aligned with the computed plan.
 - **Push to `main`:** creates tag `v<version>` and the GitHub Release (draft or final according to `.releaserc` `githubRelease.draft`).
 
-**Italiano:**
-- **Pull request verso main:** pianificazione versione, generazione release notes, sincronizzazione branch di release, creazione issue mancanti, etichettatura PR, pubblicazione della preview.
-- **Push su `release/v*`:** valida che le release notes restino allineate al piano calcolato.
-- **Push su `main`:** crea il tag `v<version>` e la GitHub Release (bozza o definitiva in base a `githubRelease.draft` in `.releaserc`).
+## Environments & forks
+Fork-originated PRs run in dry-run mode: no issues, labels, comments, or release PRs are created. This avoids unauthorised writes to external repositories.
 
-## Environments & forks / Ambienti e fork
-**English:** Fork-originated PRs run in dry-run mode: no issues, labels, comments, or release PRs are created. This avoids unauthorised writes to external repositories.
+## Manual overrides
+Besides `.release-override.yml`, adjust categories via `.releaserc`. Currently the `chore` category is excluded from publication.
 
-**Italiano:** Le PR provenienti da fork girano in modalità dry-run: non vengono create issue, label, commenti o PR di release, evitando scritture non autorizzate verso repository esterni.
-
-## Manual overrides / Override manuali
-**English:** Besides `.release-override.yml`, adjust categories via `.releaserc`. Currently the `chore` category is excluded from publication.
-
-**Italiano:** Oltre a `.release-override.yml`, puoi modificare le categorie tramite `.releaserc`. Al momento la categoria `chore` è esclusa dalla pubblicazione.
-
-## Troubleshooting / Risoluzione problemi
-**English:**
+## Troubleshooting
 - Inspect the `plan-release` job logs for detailed plans.
 - Review `.github/release-preview.md` generated locally for the full notes preview.
 - Resolve conflicts on `release/v*`, then rerun the workflow (`sync` keeps artefacts consistent).
 
-**Italiano:**
-- Controlla i log del job `plan-release` per il dettaglio del piano.
-- Consulta `.github/release-preview.md` generato localmente per la preview completa delle note.
-- Risolvi manualmente i conflitti su `release/v*` e rilancia il workflow (`sync` mantiene coerenti gli artefatti).
-
-**English:** For further customisation see `tools/release_notes/ci_release.py` and `.github/workflows/release.yml`.
-
-**Italiano:** Per ulteriori personalizzazioni consulta `tools/release_notes/ci_release.py` e `.github/workflows/release.yml`.
+For further customisation see `tools/release_notes/ci_release.py` and `.github/workflows/release.yml`.

--- a/modules/ticketing/README.md
+++ b/modules/ticketing/README.md
@@ -1,5 +1,3 @@
-# Ticketing Module / Modulo Ticketing
+# Ticketing Module
 
-**English:** Example plug-in module exposing an OpenAPI contract via Dapr invocation. It can run inside the monolith or independently.
-
-**Italiano:** Modulo plug-in di esempio che espone un contratto OpenAPI tramite invocazione Dapr. Può essere eseguito all'interno del monolite o in modo indipendente.
+Example plug-in module exposing an OpenAPI contract via Dapr invocation. It can run inside the modular monolith or independently.

--- a/tools/issue_management/README.md
+++ b/tools/issue_management/README.md
@@ -1,11 +1,9 @@
-# Issue management automation / Automazione della gestione issue
+# Issue management automation
 
-## Purpose / Scopo
-**English:** `ensure_issue_links.py` runs as part of the pull request validation pipeline to ensure every commit links to at least one issue. With `--auto-create` and the `GITHUB_TOKEN`/`OPENAI_API_KEY` variables available, the tool creates a new issue summarising the commit and updates the PR body with `Fixes #<number>`.
+## Purpose
+`ensure_issue_links.py` runs as part of the pull request validation pipeline to ensure every commit links to at least one issue. With `--auto-create` and the `GITHUB_TOKEN`/`OPENAI_API_KEY` variables available, the tool creates a new issue summarising the commit and updates the PR body with `Fixes #<number>`.
 
-**Italiano:** `ensure_issue_links.py` viene eseguito nella pipeline di verifica delle pull request per garantire che ogni commit sia collegato ad almeno una issue. Con `--auto-create` e le variabili `GITHUB_TOKEN`/`OPENAI_API_KEY` disponibili, lo strumento crea una nuova issue con il riassunto del commit e aggiorna il corpo della PR con `Fixes #<numero>`.
-
-## Manual execution / Esecuzione manuale
+## Manual execution
 ```bash
 python tools/issue_management/ensure_issue_links.py \
   --repo <owner>/<repository> \
@@ -13,14 +11,9 @@ python tools/issue_management/ensure_issue_links.py \
   --auto-create
 ```
 
-**English:** The command returns an error status when commits lack issue references. In auto mode it opens a ticket with the summary.
+The command returns an error status when commits lack issue references. In auto mode it opens a ticket with the summary.
 
-**Italiano:** Il comando restituisce uno stato di errore se sono presenti commit senza riferimento a una issue. In modalità automatica apre un ticket con il riassunto.
-
-**English:** Install Python dependencies with:
-
-**Italiano:** Installa le dipendenze Python con:
-
+Install Python dependencies with:
 ```bash
 pip install -r tools/issue_management/requirements.txt
 ```

--- a/tools/release_notes/README.md
+++ b/tools/release_notes/README.md
@@ -1,11 +1,9 @@
-# Release notes automation / Automazione delle release notes
+# Release notes automation
 
-## Purpose / Scopo
-**English:** This module contains `generate_release_notes.py`, used locally and in GitHub automation to produce release note files for the project and its modules.
+## Purpose
+This module contains `generate_release_notes.py`, used locally and in GitHub automation to produce release note files for the project and its modules.
 
-**Italiano:** Questo modulo contiene `generate_release_notes.py`, usato localmente e nell'automazione GitHub per produrre i file di release note per il progetto e i moduli.
-
-## Local usage / Utilizzo locale
+## Local usage
 ```bash
 python tools/release_notes/generate_release_notes.py \
   --release-version 1.0.0 \
@@ -15,41 +13,25 @@ python tools/release_notes/generate_release_notes.py \
   --github-token $GITHUB_TOKEN
 ```
 
-**English:** Files are generated under the repository-level `ReleaseNotes` folder and inside each module at `modules/<module-name>/ReleaseNotes/`.
+Files are generated under the repository-level `ReleaseNotes` folder and inside each module at `modules/<module-name>/ReleaseNotes/`.
 
-**Italiano:** I file vengono creati nella cartella `ReleaseNotes` del repository e nella cartella `modules/<nome-modulo>/ReleaseNotes/` di ciascun modulo.
-
-**English:** Install Python dependencies with:
-
-**Italiano:** Installa le dipendenze Python con:
-
+Install Python dependencies with:
 ```bash
 pip install -r tools/release_notes/requirements.txt
 ```
 
-## Automated release creation / Creazione automatica della release
-**English:** `tools/release_notes/create_release.py` automates the whole flow:
+## Automated release creation
+`tools/release_notes/create_release.py` automates the whole flow:
 1. Determines the next version using semantic rules by analysing commits since the latest tag.
 2. Generates release notes enriched with GitHub issue titles.
 3. Creates a `chore: release <version>` commit containing the generated files.
 4. Tags `v<version>` on `main` and creates the `release/v<version>` branch.
 
-**Italiano:** `tools/release_notes/create_release.py` automatizza l'intero flusso:
-1. Determina il prossimo numero di versione secondo le regole semantiche analizzando i commit dall'ultimo tag.
-2. Genera le release notes arricchite con i titoli delle issue GitHub.
-3. Crea un commit `chore: release <version>` con i file prodotti.
-4. Applica il tag `v<version>` su `main` e crea il branch `release/v<version>`.
-
-**English:** Example run:
-
-**Italiano:** Esempio di esecuzione:
-
+Example run:
 ```bash
 python -m tools.release_notes.create_release \
   --repo <owner>/<repository> \
   --github-token $GITHUB_TOKEN
 ```
 
-**English:** Ensure the working tree is clean and execute the command from the `main` branch.
-
-**Italiano:** Assicurati che il working tree sia pulito ed esegui il comando dal branch `main`.
+Ensure the working tree is clean and execute the command from the `main` branch.


### PR DESCRIPTION
## Summary
- remove Italian-language sections across the platform documentation and supporting READMEs
- highlight the modular monolith architecture and developer playbook throughout the docs set
- align ADRs and policies with the unified English-only guidance

## Testing
- not run (documentation-only changes)


------
https://chatgpt.com/codex/tasks/task_e_68ee96861d5c83339ef31c707c5131d4