### PR TITLE
docs: align platform references

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,6 +36,10 @@ The repository ships a ready-to-use [Dev Container](https://containers.dev/) con
 | modular-monolith | Aggregates all backend capabilities via Dapr |
 | web-core | Modular Angular frontend |
 
+### Modules
+
+- [`ticketing`](modules/ticketing/README.md): sample plug-in published via Dapr and exposed to the frontend through [`contracts/web-core/module-manifest.json`](contracts/web-core/module-manifest.json).
+
 ## End-to-end flow
 1. A raw event arrives on `telemetry.input` (Kafka).
 2. The streamer transforms it, persists to Timescale, invalidates Ignite cache, and publishes `telemetry.ingested`.
@@ -73,25 +77,26 @@ The repository ships a ready-to-use [Dev Container](https://containers.dev/) con
 
 
 ## Backlog & Outstanding Work
-- [ ] Traduzioni
-  - [ ] Sezione di gestione
-  - [ ] Astrazione per l'utilizzo a Front-End
-  - [ ] Astrazione per l'utilizzo in Back-End
-- [ ] Features flag
-  - [ ] Sessione di gestione
-  - [ ] Astrazione per l'utilizzo in Front-End
-  - [ ] Astrazione per l'utilizzo in Back-End
-- [ ] Licencing
-  - [ ] Sessione di gestione
-  - [ ] Astrazione per l'utilizzo in Front-End
-  - [ ] Astrazione per l'utilizzo in Backend
-- [ ] Federetion
-- [ ] Assets
-- [ ] Clienti
-- [ ] Spedizoni
-- [ ] Report
-- [ ] Flow manager
-- [ ] Notifier
-- [ ] Realtime
-- [ ] Stato del sistema
-- [ ] Sentry
+- **Internationalisation**
+  - [ ] Gestione delle traduzioni lato backoffice
+  - [ ] Astrazione per l'utilizzo lato frontend
+  - [ ] Astrazione per l'utilizzo lato backend
+- **Feature flags**
+  - [ ] Area di configurazione
+  - [ ] SDK/adapter per il frontend
+  - [ ] SDK/adapter per il backend
+- **Licensing**
+  - [ ] Portale di gestione licenze
+  - [ ] Integrazione lato frontend
+  - [ ] Integrazione lato backend
+- **Platform capabilities**
+  - [ ] Federation runtime hardening
+  - [ ] Gestione asset
+  - [ ] Gestione clienti
+  - [ ] Gestione spedizioni
+  - [ ] Reporting
+  - [ ] Flow manager
+  - [ ] Notifier enhancements
+  - [ ] Realtime hardening
+  - [ ] Stato del sistema
+  - [ ] Integrazione Sentry

--- a/docs/03-Versioning-Policy.md
+++ b/docs/03-Versioning-Policy.md
@@ -20,6 +20,6 @@
 
 ## Release notes
 - The manual _Generate release notes_ workflow builds release files from commits between a base ref and the target version.
-- Files land in `ReleaseNotes/` and `modules/<module-name>/ReleaseNotes/` for each affected module.
+- Files land in `ReleaseNotes/` and, when module-specific notes are produced, under `modules/<module-name>/ReleaseNotes/`.
 - Each file lists linked issues and included commits to provide full visibility.
 - During the workflow execution, a commit on `main` is created with the generated notes using the message `chore: add release notes for <version>`.

--- a/docs/06-Modular-Architecture-Guidelines.md
+++ b/docs/06-Modular-Architecture-Guidelines.md
@@ -1,8 +1,8 @@
 # Modular Architecture Guidelines
 
 ## Contracts & boundaries
-- Each module exposes independent contracts in `/contracts/<module>`.
+- Each module exposes independent contracts in `/contracts/<module>` and registers its frontend entry point inside [`contracts/web-core/module-manifest.json`](../contracts/web-core/module-manifest.json).
 - Shared use cases flow through the web-backend-core orchestrator via Dapr gRPC.
 - Module federation lets every micro-frontend expose its entry point as a remote.
 - Backend plug-ins register through Dapr service discovery.
-- The modular monolith hosts modules behind a unified façade; when extracting services, keep the same contracts to maintain backwards compatibility.
+- The modular monolith hosts modules behind a unified façade; when extracting services, keep the same contracts to maintain backwards compatibility. Use existing examples such as [`modules/ticketing`](../modules/ticketing/README.md) as a baseline for additional plug-ins.

--- a/docs/07-Observability-Guidelines.md
+++ b/docs/07-Observability-Guidelines.md
@@ -4,6 +4,6 @@
 - OpenTelemetry SDK is configured in all services for metrics and traces.
 - Default export path: OTLP → Tempo, Prometheus scrape, Loki for logs.
 - Every service exposes `/healthz` and `/metrics` endpoints.
-- Grafana dashboards are versioned under `observability/dashboards` (TODO).
+- Grafana dashboards will be versioned under `observability/dashboards/` once the first dashboards are published (TODO).
 - Observability stack relies exclusively on OSS components (Prometheus, Loki, Tempo, Grafana OSS).
 - Modular monolith deployments emit the same telemetry envelopes to ensure consistent dashboards regardless of runtime topology.


### PR DESCRIPTION
## Summary
- highlight the ticketing module from the services overview and fix the backlog wording in the README
- clarify where module-specific release notes land in the versioning policy
- link modular architecture guidance to the manifest and sample module while noting the pending observability dashboards

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68f3cb3ab86083339104578f104e08ef
- Closes #185 (commit 18bd737)