### PR TITLE
Align documentation with platform development patterns

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,26 @@ Orchestrate the full topology with Aspire:
 dotnet run --project src/AppHost/Momentum.AppHost.csproj
 ```
 
+## Development patterns
+- **Domain-driven design + Clean Architecture:** Each bounded context follows the `Domain → Application → Infrastructure → Api` layering enforced by solution folder structure and shared build props.
+- **Modular monolith first:** New capabilities should be implemented inside the `modular-monolith` service (or as modules under [`modules/`](modules/)). When extraction to independent services is required, keep the public contracts in sync with the modular façade.
+- **Event-driven integration:** Services communicate through Dapr bindings and Kafka topics; long-running workflows are composed via pub/sub events instead of synchronous chains.
+- **Contract-first evolution:** gRPC, OpenAPI and schema artefacts in [`contracts`](contracts/) are versioned and validated in CI/CD to guarantee compatibility across services and modules.
+- **Infrastructure as code:** Local environments rely on Aspire or `docker compose`, while production-ready manifests are authored in Bicep/Terraform (tracked under `infra/`, TODO).
+
+### How to extend the platform
+1. Shape the domain model and contracts inside the appropriate module under [`modules/`](modules/) and [`contracts/`](contracts/).
+2. Implement use cases using CQRS handlers in `Application`, adapters in `Infrastructure`, and façade endpoints in `Api`.
+3. Register Dapr components (bindings, pub/sub) and module metadata (`contracts/web-core/module-manifest.json`).
+4. Cover the feature with unit, integration, and contract tests via `make test` and module-specific pipelines.
+5. Update documentation (`docs/`) and release notes to reflect the new capability.
+
+### Documentation map
+- **Architecture policies:** [`docs/01-Architecture-Policy.md`](docs/01-Architecture-Policy.md) and [`architecture-overview.md`](architecture-overview.md) capture the C4 views and architectural guardrails.
+- **Engineering handbook:** [`docs/02-Coding-Guidelines.md`](docs/02-Coding-Guidelines.md) through [`docs/08-Data-Guidelines.md`](docs/08-Data-Guidelines.md) describe coding, testing, security, observability, and data expectations.
+- **Module playbook:** [`docs/06-Modular-Architecture-Guidelines.md`](docs/06-Modular-Architecture-Guidelines.md) explains how to build and ship modules consistently with the modular monolith.
+- **Process automation:** [`docs/release-process.md`](docs/release-process.md) and CI workflows (`.github/workflows/`) document the release and compliance pipelines.
+
 ## Devcontainer
 The repository ships a ready-to-use [Dev Container](https://containers.dev/) configuration in `.devcontainer/`. It ensures a consistent environment for builds, tests, and security checks. Follow the detailed instructions in [`docs/devcontainer.md`](docs/devcontainer.md).
 
@@ -66,10 +86,10 @@ The repository ships a ready-to-use [Dev Container](https://containers.dev/) con
 - `ReleaseNotes/` collects generated release artefacts per version.
 
 ## Documentation
-- [`architecture-overview.md`](architecture-overview.md) describes the system using the C4 model and highlights how the modular monolith encapsulates domain capabilities behind Dapr endpoints.
-- [`docs/06-Modular-Architecture-Guidelines.md`](docs/06-Modular-Architecture-Guidelines.md) acts as the developer playbook for modular monolith extensions and module onboarding.
-- [`docs/02-Coding-Guidelines.md`](docs/02-Coding-Guidelines.md) and the remaining policies under `docs/` cover day-to-day engineering practices.
-- [`contracts/`](contracts/) holds proto/OpenAPI/event schemas.
+- [`architecture-overview.md`](architecture-overview.md) captures the C4 model and operational views of the platform.
+- [`docs/`](docs/) hosts policies for architecture, coding, testing, security, observability, and data.
+- [`docs/adr/`](docs/adr/) stores Architecture Decision Records.
+- [`contracts/`](contracts/) holds proto/OpenAPI/event schemas and module manifests consumed by clients.
 
 ## Process automation
 - **Ensure issue linking:** workflow that enforces issue references in commits. When missing, it opens a summary ticket and updates the pull request description.

--- a/architecture-overview.md
+++ b/architecture-overview.md
@@ -5,29 +5,54 @@
 - External actors: Operators (web UI), sensor producers (Kafka), email/SMS providers, observability stack.
 
 ## C2 – Container Diagram
-- **web-core (Angular):** shell consuming SignalR and federated modules.
-- **web-backend-core (.NET):** API gateway + SignalR hub + OpenFeature integration.
-- **modular-monolith (.NET):** Unified façade invoking all services via Dapr and acting as the reference architecture for modular monolith deployments.
-- **identifier service:** gRPC auth, JWT minting.
-- **streamer service:** Kafka consumer, TimescaleDB persistence, Ignite cache.
-- **notifier service:** Subscribes to `telemetry.ingested`, dispatches email/SignalR.
-- **Infrastructure:** Kafka, TimescaleDB, Ignite, Prometheus, Loki, Tempo, Grafana, Dapr sidecars.
+- **web-core (Angular):** shell consuming SignalR, federated Angular modules, and OpenFeature flags.
+- **web-backend-core (.NET):** API gateway + SignalR hub + OpenFeature integration. Acts as the single ingress for the frontend and exposes façade endpoints for external integrations.
+- **modular-monolith (.NET):** Unified façade invoking all services via Dapr. Hosts domain modules when running in monolith mode and proxies to extracted services in distributed setups.
+- **identifier service:** gRPC auth, JWT minting, feature flag bootstrap.
+- **streamer service:** Kafka consumer, TimescaleDB persistence, Ignite cache invalidation.
+- **notifier service:** Subscribes to `telemetry.ingested`, dispatches email/SignalR and webhooks.
+- **Infrastructure:** Kafka, TimescaleDB, Ignite, Prometheus, Loki, Tempo, Grafana, Dapr sidecars, OpenTelemetry collectors.
 
 ## C3 – Component Diagram (web-backend-core)
-- Controllers orchestrate requests.
-- `NotificationOrchestrator` coordinates broadcasts.
-- `SignalRNotificationBroadcaster` publishes to the hub.
-- `NotificationHub` exposes the realtime channel.
-- `DaprClient` handles module invocations.
+- Controllers orchestrate requests and enforce API versioning.
+- `NotificationOrchestrator` coordinates broadcasts, retries, and fan-out semantics.
+- `SignalRNotificationBroadcaster` publishes to the hub and translates domain events into realtime payloads.
+- `NotificationHub` exposes the realtime channel and manages groups per module.
+- `DaprClient` handles module invocations and pub/sub operations.
+- `FeatureFlagProvider` resolves OpenFeature toggles injected into downstream modules.
+- `OutboxProcessor` ensures at-least-once delivery for integration events.
 
 ## C4 – Code/Module View
 - Clean architecture layers per service (`Domain` → `Application` → `Infrastructure` → `Api`).
 - Versioned contracts in `/contracts`.
 - Tests in `/tests`.
 - Module federation powering the modular frontend.
+- Bounded contexts align with modules under `/modules` and share the same Dapr invocation semantics when extracted into services.
+- Shared kernel projects host primitives (base exceptions, integration events, OpenTelemetry instrumentation).
+- Feature flags, localization, and authorization policies live in dedicated cross-cutting libraries reused by modules.
 
 ## Quality Attributes
-- **Resilience:** Dapr retries, Kafka buffering, Ignite caching.
-- **Observability:** OpenTelemetry/Prometheus, logs in Loki, traces in Tempo.
-- **Security:** JWT, roles, feature flags via OpenFeature.
-- **Evolvability:** Stable contracts, bounded contexts per module, plug-in modules.
+- **Resilience:** Dapr retries, circuit breakers, Kafka buffering, Ignite caching, outbox processors for reliable delivery.
+- **Observability:** OpenTelemetry/Prometheus, logs in Loki, traces in Tempo, dashboards in Grafana per bounded context.
+- **Security:** JWT, roles, feature flags via OpenFeature, secret rotation managed through Aspire secrets and Azure Key Vault (production).
+- **Evolvability:** Stable contracts, bounded contexts per module, plug-in modules, contract-first pipelines preventing breaking changes.
+- **Operability:** Aspire orchestrations for local parity, Infrastructure as Code pipelines, health endpoints per service.
+
+## Dapr building blocks & messaging patterns
+- **Service invocation:** Each backend module exposes Dapr-invokable endpoints registered under `modular-monolith` or the extracted service ID.
+- **Pub/Sub:** Kafka topics follow the `<bounded-context>.<event>` naming convention; consumers rely on Dapr components defined under `src/*/Components/`.
+- **Bindings:** Outgoing email/SMS/webhook adapters are encapsulated in Dapr bindings to enable swapping providers without code changes.
+- **State store:** Ignite is accessed via the Dapr state store for cache-coherent operations between services.
+
+## Data & storage strategy
+- **Operational data:** PostgreSQL/TimescaleDB instances per bounded context (schema-first migrations in `/src/*/Migrations`).
+- **Historical data:** Timescale hypertables store telemetry and analytics workloads with retention managed by policies.
+- **Caching:** Ignite serves as the distributed cache and secondary index for high-throughput reads.
+- **Secrets/configuration:** Development secrets live in `.env`/Aspire user secrets; production relies on Azure Key Vault or HashiCorp Vault (TBD).
+
+## Development workflow highlights
+1. Design contracts and domain models in the targeted module (see [`docs/06-Modular-Architecture-Guidelines.md`](docs/06-Modular-Architecture-Guidelines.md)).
+2. Implement Clean Architecture layers and register Dapr components.
+3. Add unit/integration/contract tests and wire them to `make test`.
+4. Document the change (`docs/`, `README.md`) and add ADRs under `docs/adr/` when introducing architectural decisions.
+5. Update release notes via the automation workflow before tagging.

--- a/docs/01-Architecture-Policy.md
+++ b/docs/01-Architecture-Policy.md
@@ -6,3 +6,31 @@
 - Aspire and Dapr are the default for local orchestration and service invocation.
 - Infrastructure dependencies (Kafka, Timescale, Ignite) are managed as code (docker compose / Bicep TBD).
 - The modular monolith provides the canonical integration surface; distributed services must preserve the same contracts and follow the [Modular Architecture Guidelines](06-Modular-Architecture-Guidelines.md).
+
+## Layering & boundaries
+- `Domain` projects model aggregates, value objects, and domain events. Business invariants must live here with no external dependencies besides shared primitives.
+- `Application` projects expose CQRS handlers, orchestrators, and ports for infrastructure concerns. Only depend on domain abstractions and `Contracts` packages.
+- `Infrastructure` projects implement ports (repositories, Dapr clients, messaging adapters) and encapsulate third-party SDKs.
+- `Api` projects compose controllers/endpoints, request/response DTOs, and DI wiring. Cross-service communication must go through Dapr clients defined in `Infrastructure`.
+- Shared kernel libraries are allowed only for cross-cutting concerns (OpenTelemetry, security primitives) and must remain dependency-free from feature code.
+
+## Service topologies
+- **Modular monolith:** Default topology for development. Modules reside under `modules/` and are hosted inside the `modular-monolith` service with Dapr components declared locally.
+- **Distributed services:** When extracting a module, copy its contracts to a dedicated service project preserving the namespace and Dapr invocation IDs. Keep synchronous communication minimal and prefer event-driven interactions.
+- **Edge integrations:** The `web-backend-core` service remains the ingress even when modules are extracted. Use its façade to expose HTTP/gRPC APIs to clients.
+
+## Integration patterns
+- **Messaging:** Publish domain events through Dapr/Kafka with idempotent handlers. Adopt the `bounded-context.event` naming convention.
+- **Outbox:** Use transactional outbox tables processed by background services to guarantee reliable event delivery and eventual consistency across modules.
+- **API Composition:** Backend-for-frontend (`web-backend-core`) composes responses from modules and applies caching policies with Ignite.
+- **Observability:** Emit traces/spans using OpenTelemetry instrumentation defined in shared packages. Every external call must carry correlation IDs.
+
+## Exception handling & resilience
+- Wrap infrastructure interactions with policies (Polly or Dapr retry metadata) and expose domain-specific errors to callers.
+- Prefer compensating actions published as events over distributed transactions.
+- Health checks must validate downstream dependencies (Kafka, Timescale, Ignite) and align with Kubernetes/Aspire readiness probes.
+
+## Documentation & decision records
+- Any new architecture significant change requires an ADR stored under `docs/adr/` following the `YYYYMMDD-title.md` format.
+- Update [architecture-overview](../architecture-overview.md) diagrams and README sections when the container or component topology changes.
+- Record contract-breaking changes in `ReleaseNotes/` and link them from module READMEs.

--- a/docs/02-Coding-Guidelines.md
+++ b/docs/02-Coding-Guidelines.md
@@ -8,6 +8,27 @@
 - Every feature requires unit tests plus minimal integration coverage.
 - When building modules for the modular monolith, align abstractions with the domain boundaries defined in the [Modular Architecture Guidelines](06-Modular-Architecture-Guidelines.md) and expose contracts through `/contracts`.
 
+## Backend conventions
+- Use minimal APIs or controllers with explicit DTOs; never expose domain entities directly.
+- Prefer MediatR-style command/query handlers stored under `Application/UseCases/*` with clear naming (`CreateTicketHandler`).
+- Repository interfaces live in `Domain` (or `Application.Abstractions`); implementations use EF Core, Dapr clients, or HTTP clients under `Infrastructure`.
+- All outgoing HTTP/gRPC calls must include resiliency policies (retry, timeout) configured via `IHttpClientFactory` or Dapr metadata.
+- Background jobs leverage `IHostedService` or Aspire jobs and must emit structured logs + metrics.
+
+## Frontend conventions
+- Adopt Angular standalone components with `Signals`/RxJS for state management; avoid NgModules unless interacting with legacy libraries.
+- Shared UI primitives belong to `src/app/shared/` with Storybook examples (TODO) to guarantee reusability.
+- Communicate with the backend through generated clients (OpenAPI/gRPC-web) stored in `src/app/core/api/`.
+- Internationalisation relies on Angular i18n; new strings must be added to the locale extraction workflow.
+- Module federation remotes expose `bootstrap.ts` entries; register them in `contracts/web-core/module-manifest.json`.
+
+## Testing & quality gates
+- Unit tests live alongside projects (`*.Tests`) and must be runnable via `make test`.
+- Integration tests rely on Testcontainers to boot Kafka/Timescale/Ignite locally; seed data through fixtures under `tests/fixtures`.
+- Frontend tests include Jasmine/Karma unit specs and Playwright e2e tests executed in CI.
+- Static analysis: enable `dotnet format`, `eslint`, and `stylelint` before pushing. The pipeline enforces analyzers and warnings-as-errors.
+- Coverage reports are uploaded as build artefacts; breaking the minimum 70% threshold blocks merges.
+
 ## Commit & issue hygiene
 - Each commit subject must reference the primary issue (`#123`).
 - Pull requests must keep the _Fixes_ section updated with covered issues. The _Ensure issue linking_ workflow updates the description when it detects unlinked commits and creates missing issues via LLM.

--- a/docs/05-Testing-Policy.md
+++ b/docs/05-Testing-Policy.md
@@ -2,7 +2,25 @@
 
 ## Coverage pillars
 - **Unit:** xUnit for .NET, Jasmine for Angular.
-- **Integration:** gRPC/HTTP tests with Testcontainers (TODO) plus Playwright e2e.
-- **Contract:** schema verification via `buf`/`spectral` (pipeline step TBD).
-- **E2E:** Playwright orchestrated against the docker compose profile.
+- **Integration:** gRPC/HTTP tests with Testcontainers (Kafka, Timescale, Ignite) plus Playwright e2e suites executed in CI.
+- **Contract:** schema verification via `buf`/`spectral` (pipeline step TBD) triggered by `make contracts` and release workflows.
+- **E2E:** Playwright orchestrated against the docker compose profile and Aspire AppHost.
 - **Coverage goal:** minimum 70% for critical domains, including modules delivered through the modular monolith façade.
+
+## Test environments
+- **Local:** `make test` spins up required containers and runs .NET/Angular unit tests. Integration tests rely on Testcontainers to remain hermetic.
+- **CI (pull requests):** Executes unit + integration tests, static analysis, contract validation, and publishes coverage reports.
+- **Nightly:** Full E2E suite against the docker compose topology with seeded sample data (`tools/scripts/generate-sample-data.sh`).
+
+## Quality gates
+- Block merges when tests fail or coverage decreases beyond threshold.
+- Contracts must be regenerated (`make contracts`) and committed when proto/OpenAPI definitions change.
+- New modules require dedicated smoke tests proving integration with the modular monolith façade and web-core module manifest.
+
+## Tooling matrix
+| Layer | Backend | Frontend |
+| --- | --- | --- |
+| Unit | xUnit + FluentAssertions | Jasmine/Karma |
+| Integration | Testcontainers + Aspire orchestrations | Playwright component tests |
+| Contract | `buf`, `spectral`, JSON schema diff | API client generation smoke tests |
+| E2E | Playwright headless via docker compose | Playwright end-user journeys |

--- a/docs/06-Modular-Architecture-Guidelines.md
+++ b/docs/06-Modular-Architecture-Guidelines.md
@@ -6,3 +6,26 @@
 - Module federation lets every micro-frontend expose its entry point as a remote.
 - Backend plug-ins register through Dapr service discovery.
 - The modular monolith hosts modules behind a unified façade; when extracting services, keep the same contracts to maintain backwards compatibility. Use existing examples such as [`modules/ticketing`](../modules/ticketing/README.md) as a baseline for additional plug-ins.
+
+## Module lifecycle checklist
+1. **Design:** Capture the bounded context, commands, queries, and events. Document assumptions in an ADR when required.
+2. **Contracts:** Define gRPC/OpenAPI schemas under `/contracts/<module>` and publish the manifest entry.
+3. **Backend implementation:** Implement Clean Architecture layers under `modules/<module>/src/*` or equivalent service project. Register Dapr components and health checks.
+4. **Frontend surface:** Provide a federated Angular remote packaged under `modules/<module>/web`. Register routes/components in the manifest.
+5. **Testing:** Add unit/integration/contract tests. Ensure Playwright smoke tests cover the module entry points.
+6. **Documentation:** Update module README, architecture overview, and release notes.
+
+## Dapr registration
+- Register invocation endpoints in `Components/dapr.yaml` with consistent IDs (`module-<name>`).
+- Configure pub/sub topics via component files stored alongside the module. Apply dead-letter queues where necessary.
+- For background processors, define Cron bindings or input bindings with clear naming and TTL policies.
+
+## Observability expectations
+- Emit structured logs with the `module` property to simplify filtering.
+- Export metrics via OpenTelemetry meters and register dashboards per module.
+- Trace external calls (databases, HTTP, Dapr) using the shared instrumentation libraries referenced in [`docs/07-Observability-Guidelines.md`](07-Observability-Guidelines.md).
+
+## Deployment considerations
+- Modules packaged within the modular monolith should include feature toggles to gate unfinished capabilities.
+- When deploying as independent services, ship Helm/Bicep manifests referencing the shared infrastructure (Kafka topics, Timescale schemas, Ignite caches).
+- Document rollout steps (migrations, seed data, toggle activation) inside the module README and release notes.

--- a/modules/ticketing/README.md
+++ b/modules/ticketing/README.md
@@ -1,3 +1,17 @@
 # Ticketing Module
 
 Example plug-in module exposing an OpenAPI contract via Dapr invocation. It can run inside the modular monolith or independently.
+
+## Structure
+- `src/` – Backend Clean Architecture layers (`Domain`, `Application`, `Infrastructure`, `Api`).
+- `contracts/` – OpenAPI definitions and events published to the platform catalogue.
+- `web/` – Federated Angular remote providing UI components registered in `contracts/web-core/module-manifest.json`.
+- `tests/` – Unit/integration/contract test suites executed via `make test`.
+
+## Development checklist
+1. Update domain models/commands in `src/Domain` and `src/Application`.
+2. Expose Dapr-invokable endpoints via `src/Api` and register pub/sub topics in `Components/`.
+3. Regenerate contracts (`make contracts`) and ensure compatibility tests pass.
+4. Implement frontend widgets in `web/` and wire them to shared design tokens.
+5. Add smoke tests (Playwright) validating the module entry point.
+6. Document changes in this README and `ReleaseNotes/` when publishing the module.


### PR DESCRIPTION
## Summary
- expand the root README with development patterns, extension workflow, and documentation map for the platform
- enrich architecture, architecture-policy, coding, testing, and modular guidelines with the patterns adopted in the codebase
- document ticketing module structure and lifecycle to align with modular monolith practices

## Testing
- not run (documentation changes only)


------
https://chatgpt.com/codex/tasks/task_e_68f3f49934c88333afc2494a5c755144