### PR TITLE
docs: align documentation with runtime topology and update discrepancy report

### DIFF
--- a/CHANGELOG_DOCS.md
+++ b/CHANGELOG_DOCS.md
@@ -1,0 +1,41 @@
+# Documentation Changelog
+
+## 2025-12-24
+
+### Updated
+- `README.md`
+  - Clarified Aspire vs Docker Compose runtime topologies, Dapr availability, and service coverage.
+  - Corrected telemetry flow description to match streamer/notifier behavior.
+  - Updated stack notes for OpenTelemetry and caching status.
+
+- `architecture-overview.md`
+  - Aligned container/component diagrams and event flow with the actual services and code.
+  - Corrected Dapr component references and data storage notes.
+
+- `docs/01-Architecture-Policy.md`
+  - Updated ADR naming guidance and clarified IaC status.
+
+- `docs/04-Security-Policy.md`
+  - Replaced Key Vault/OpenFeature binding statements with the current JWT/OpenFeature configuration.
+
+- `docs/05-Testing-Policy.md`
+  - Documented real test tooling, CI checks, and contract validation flow.
+
+- `docs/06-Modular-Architecture-Guidelines.md`
+  - Updated contract locations and module scaffolding guidance based on the repository structure.
+
+- `docs/07-Observability-Guidelines.md`
+  - Documented actual health/metrics endpoints and exporter status.
+
+- `docs/identifier/README.md`
+  - Corrected database engine, connection strings, ports, integration test setup, and Dapr seed topic.
+
+### Added
+- `REPORT_DISCREPANZE.md`
+  - Added discrepancy report, reality map, and documentation update plan.
+
+- `CHANGELOG_DOCS.md`
+  - Added documentation changelog.
+
+- `REPORT_DISCREPANZE.md`
+  - Added explicit “Files to remove” and “Files added” sections for traceability.

--- a/REPORT_DISCREPANZE.md
+++ b/REPORT_DISCREPANZE.md
@@ -1,0 +1,113 @@
+# Documentation Discrepancy Report (Momentum)
+
+## Phase 0 — Inventory
+
+### Repository structure (top-level)
+- `src/` (services, shared libraries, web-core)
+- `contracts/` (proto/OpenAPI schemas and module manifest)
+- `modules/` (sample module docs/contracts)
+- `docs/` (architecture, policies, security, ADRs)
+- `tests/` (backend + frontend tests)
+- `tools/` (release automation, security, CI helpers)
+- `docker-compose*.yml`, `Makefile`, `Momentum.sln`
+
+### Documentation files discovered
+- `README.md`, `architecture-overview.md`
+- `docs/**/*.md` (architecture, guidelines, policies, ADRs, devcontainer)
+- `modules/ticketing/README.md`
+- `tools/**/README.md`
+- `ReleaseNotes/*.md`, `SECURITY.md`
+
+### Stack/toolchain (evidence)
+- .NET 8 SDK (`global.json`)
+- Aspire AppHost + Dapr sidecars (`src/AppHost/AppHost.cs`)
+- Angular 19 (`src/web-core/package.json`)
+- Docker Compose runtime (`docker-compose.yml`)
+- CI workflows (`.github/workflows/*.yml`)
+
+## Phase 1 — Reality map
+
+### Entrypoints & runtime topologies
+- **Aspire AppHost**: `dotnet run --project src/AppHost/Momentum.AppHost.csproj` provisions infra containers + Dapr sidecars and starts `core-web`, `identifier`, `streamer`, `notifier`, `web-backend-core`, `modular-monolith`, `web-core` container (`src/AppHost/AppHost.cs`).
+- **Docker Compose**: `docker compose up` provisions Kafka (Redpanda), Timescale, Ignite, Prometheus/Loki/Tempo/Grafana and starts `identifier`, `streamer`, `notifier`, `web-backend-core`, `web-core` (`docker-compose.yml`). Dapr sidecars are not part of this topology.
+
+### Core services & responsibilities
+- `core-web` API: manifest/menu/i18n/auth endpoints + SignalR hub (`src/services/core-web/CoreWeb.Api/Program.cs`).
+- `web-backend-core`: API gateway + SignalR hub, OpenFeature in-memory provider (`src/services/web-backend-core/WebBackendCore.Api/Program.cs`).
+- `identifier`: RBAC/licensing/flags, HTTP + gRPC, PostgreSQL/Timescale persistence (`src/services/identifier/Identifier.Api/Program.cs`).
+- `streamer`: Kafka consumer → Timescale persistence → Dapr pub/sub (`src/services/streamer/Streamer.Infrastructure/*`).
+- `notifier`: Dapr subscriber to `telemetry.ingested`, dispatches SignalR + email (`src/services/notifier/Notifier.Api/Controllers/SubscriptionsController.cs`, `Notifier.Infrastructure/Channels/*`).
+
+### Contracts & APIs
+- gRPC/OpenAPI contracts in `contracts/*` (e.g. `contracts/identifier/identifier.proto`, `contracts/web-backend-core/orchestrator.yaml`).
+- Module manifest in `contracts/web-core/module-manifest.json`.
+
+### Configuration & dependencies
+- AppHost uses Timescale, Kafka (Redpanda), Ignite, Prometheus/Loki/Tempo/Grafana, Redis container (provisioned only), and Dapr components under `src/AppHost/mounts/dapr/components` (currently placeholder files).
+- Compose uses the same infra containers but does not mount or run Dapr sidecars.
+
+### CI/CD
+- `pr-gate.yml` runs .NET build/test, frontend lint/tests, and JSON schema validation (`tests/Contracts/schema-validation.test.sh`).
+- `release.yml` drives release automation (`tools/release_notes/ci_release.py`).
+- `security-pr.yml` runs the security suite (`tools/security/run-all.sh`).
+
+## Phase 2 — Documentation vs reality (mismatch table)
+
+| File/Section | Type | Evidence | Proposed action |
+| --- | --- | --- | --- |
+| `README.md` stack/quick start/deployment | O/E | `docker-compose.yml`, `src/AppHost/AppHost.cs`, `Makefile` | Clarify compose vs Aspire topology, Dapr availability, and service coverage. |
+| `README.md` end-to-end flow | E | `Streamer.Infrastructure/Ingestion/*`, `Notifier.Api/*` | Remove Ignite cache invalidation and describe actual Dapr/Kafka + SignalR flow. |
+| `architecture-overview.md` C3 components | E | `src/services/web-backend-core/*` (no Outbox/FeatureFlagProvider) | Update diagram and component list to match code. |
+| `architecture-overview.md` data & Dapr sections | E/O | `src/AppHost/mounts/dapr/components/*`, `src/services/*/Migrations` | Note placeholder Dapr components and actual migrations usage. |
+| `docs/01-Architecture-Policy.md` ADR naming | E | `docs/adr/0001.md` | Align ADR naming guidance with current numbering. |
+| `docs/04-Security-Policy.md` controls | E | `src/services/core-web/CoreWeb.Api/Program.cs`, `src/services/web-backend-core/WebBackendCore.Api/Program.cs` | Remove Key Vault/OpenFeature binding claims; document current config. |
+| `docs/05-Testing-Policy.md` test flow | E/O | `Makefile`, `.github/workflows/pr-gate.yml`, `tests/Identifier/*` | Replace buf/spectral/Testcontainers claims with actual CI and tests. |
+| `docs/06-Modular-Architecture-Guidelines.md` contracts/modules layout | E | `contracts/`, `modules/ticketing/README.md` | Clarify service-centric contracts and current module state. |
+| `docs/07-Observability-Guidelines.md` endpoints/export | E | `src/services/*/Program.cs` | Update health/metrics endpoints and exporter status. |
+| `docs/identifier/README.md` database/ports/tests | E | `Identifier.Api/appsettings.json`, `IdentifierDbContextFactory.cs`, `Identifier.Api/Program.cs`, `tests/Identifier/*` | Update to Postgres, correct ports, Testcontainers usage, and Dapr seed topic. |
+
+Legend: (M) Missing, (O) Obsolete, (E) Erroneous, (D) Duplicate.
+
+## Phase 3 — Plan of modification (file-by-file)
+
+- `README.md`
+  - Clarify Docker Compose vs Aspire behavior and Dapr availability.
+  - Fix end-to-end flow to match streamer/notifier behavior.
+  - Note actual service list coverage per topology.
+- `architecture-overview.md`
+  - Update container/component diagrams, remove nonexistent components.
+  - Align Dapr, data, and event flow sections with current code.
+- `docs/01-Architecture-Policy.md`
+  - Update ADR naming guidance and IaC statement.
+- `docs/04-Security-Policy.md`
+  - Replace Key Vault/OpenFeature binding claims with current JWT + OpenFeature setup.
+- `docs/05-Testing-Policy.md`
+  - Document actual tests, CI workflow, and schema validation approach.
+- `docs/06-Modular-Architecture-Guidelines.md`
+  - Align contract locations and module scaffolding guidance.
+- `docs/07-Observability-Guidelines.md`
+  - Document real health/metrics endpoints and exporter status.
+- `docs/identifier/README.md`
+  - Correct DB engine/connection strings, ports, and integration test description.
+  - Add Dapr seed topic note and gRPC surface reference.
+- Add `REPORT_DISCREPANZE.md` and `CHANGELOG_DOCS.md`.
+
+## Phase 4 — Applied changes
+All modifications listed above have been applied to the respective documentation files.
+
+## Files to remove
+- None. (No obsolete documentation files were removed in this pass.)
+
+## Files added
+- `REPORT_DISCREPANZE.md` (discrepancy report and update plan)
+- `CHANGELOG_DOCS.md` (documentation changelog)
+
+## Phase 5 — Final validation checks
+- Commands cited cross-checked against `Makefile`, `docker-compose.yml`, and `src/*/Program.cs`.
+- Environment variables aligned with configuration files (notably `ConnectionStrings__Identifier`).
+- API routes verified against `src/services/*/Program.cs` and `contracts/*`.
+- Internal links preserved.
+
+## Open items / to verify
+- Dapr component YAML files under `src/AppHost/mounts/dapr/components` are empty; Dapr pub/sub configuration must be filled before local Dapr flows will work.
+- `docker-compose.yml` does not currently set `ConnectionStrings__Identifier`; identifier containers need an override to connect to Timescale.

--- a/architecture-overview.md
+++ b/architecture-overview.md
@@ -2,25 +2,25 @@
 
 ## C1 – System Context
 - **Momentum Platform** ingests telemetry, manages identities, and broadcasts notifications.
-- External actors: Operators (web UI), sensor producers (Kafka), email/SMS providers, observability stack.
+- External actors: Operators (web UI), sensor producers (Kafka), email providers (Azure Communication Email), observability stack.
 
 ```mermaid
 flowchart LR
     Operators([Operators]) --> MomentumPlatform[[Momentum Platform]]
     SensorProducers([Sensor Producers]) --> MomentumPlatform
     MomentumPlatform --> EmailProviders([Email Providers])
-    MomentumPlatform --> SMSProviders([SMS Providers])
     MomentumPlatform --> Observability([Observability Stack])
 ```
 
 ## C2 – Container Diagram
-- **web-core (Angular):** shell consuming SignalR, federated Angular modules, and OpenFeature flags.
-- **web-backend-core (.NET):** API gateway + SignalR hub + OpenFeature integration. Acts as the single ingress for the frontend and exposes façade endpoints for external integrations.
-- **modular-monolith (.NET):** Unified façade invoking all services via Dapr. Hosts domain modules when running in monolith mode and proxies to extracted services in distributed setups.
-- **identifier service:** gRPC auth, JWT minting, feature flag bootstrap.
-- **streamer service:** Kafka consumer, TimescaleDB persistence, Ignite cache invalidation.
-- **notifier service:** Subscribes to `telemetry.ingested`, dispatches email/SignalR and webhooks.
-- **Infrastructure:** Kafka, TimescaleDB, Ignite, Prometheus, Loki, Tempo, Grafana, Dapr sidecars, OpenTelemetry collectors.
+- **web-core (Angular):** shell consuming SignalR, federated Angular modules, and translation resources.
+- **core-web (.NET):** UI gateway for manifest/menu/i18n/auth and SignalR hub for shell events.
+- **web-backend-core (.NET):** API gateway + SignalR hub + OpenFeature in-memory provider. Exposes façade endpoints for external integrations and notification broadcasts.
+- **modular-monolith (.NET):** Unified façade invoking services via Dapr. Hosts domain modules when running in monolith mode and proxies to extracted services in distributed setups.
+- **identifier service:** gRPC + HTTP auth, licensing, feature flags (PostgreSQL/Timescale backed).
+- **streamer service:** Kafka consumer, TimescaleDB persistence, publishes `telemetry.ingested` via Dapr.
+- **notifier service:** Subscribes to `telemetry.ingested`, dispatches email and SignalR (via `web-backend-core` hub).
+- **Infrastructure:** Kafka (Redpanda in compose), TimescaleDB, Ignite (provisioned), Prometheus, Loki, Tempo, Grafana, Dapr sidecars (Aspire).
 
 ```mermaid
 flowchart LR
@@ -28,6 +28,7 @@ flowchart LR
         WebCore[web-core - Angular]
     end
     subgraph Backend
+        CoreWeb[core-web - .NET]
         WebBackend[web-backend-core - .NET]
         ModularMonolith[modular-monolith - .NET]
         Identifier[identifier service]
@@ -40,11 +41,10 @@ flowchart LR
         Ignite[(Ignite)]
         ObservabilityStack[[Prometheus/Loki/Tempo/Grafana]]
         Dapr[Dapr Sidecars]
-        OTEL[OpenTelemetry Collectors]
     end
 
     Operators([Operators]) --> WebCore
-    WebCore --> WebBackend
+    WebCore --> CoreWeb
     WebBackend --> ModularMonolith
     WebBackend --> Identifier
     ModularMonolith --> Streamer
@@ -53,6 +53,7 @@ flowchart LR
     Notifier --> Kafka
     ModularMonolith --> Timescale
     ModularMonolith --> Ignite
+    CoreWeb --> Dapr
     WebBackend --> Dapr
     ModularMonolith --> Dapr
     Streamer --> Dapr
@@ -60,29 +61,22 @@ flowchart LR
     Kafka --> ObservabilityStack
     Timescale --> ObservabilityStack
     Ignite --> ObservabilityStack
-    Dapr --> OTEL
 ```
 
 ## C3 – Component Diagram (web-backend-core)
-- Controllers orchestrate requests and enforce API versioning.
-- `NotificationOrchestrator` coordinates broadcasts, retries, and fan-out semantics.
-- `SignalRNotificationBroadcaster` publishes to the hub and translates domain events into realtime payloads.
-- `NotificationHub` exposes the realtime channel and manages groups per module.
-- `DaprClient` handles module invocations and pub/sub operations.
-- `FeatureFlagProvider` resolves OpenFeature toggles injected into downstream modules.
-- `OutboxProcessor` ensures at-least-once delivery for integration events.
+- Controllers orchestrate requests and call the application layer.
+- `NotificationOrchestrator` coordinates broadcasts and appends events to the in-memory `NotificationStream`.
+- `SignalRNotificationBroadcaster` publishes to the hub.
+- `NotificationHub` exposes the realtime channel for UI consumers.
+- OpenFeature is configured with an in-memory provider during startup.
 
 ```mermaid
 flowchart TD
     Controllers[Controllers] --> Orchestrator[NotificationOrchestrator]
+    Orchestrator --> Stream[NotificationStream]
     Orchestrator --> Broadcaster[SignalRNotificationBroadcaster]
-    Orchestrator --> DaprClient[DaprClient]
-    Orchestrator --> FeatureFlags[FeatureFlagProvider]
     Broadcaster --> NotificationHub[NotificationHub]
-    DaprClient --> Outbox[OutboxProcessor]
-    DaprClient --> Modules[Domain Modules]
-    FeatureFlags --> Modules
-    Outbox --> Integrations[Integration Events]
+    FeatureFlags[OpenFeature In-Memory Provider] --> Controllers
 ```
 
 ## C4 – Code/Module View
@@ -102,16 +96,16 @@ flowchart TD
 - **Operability:** Aspire orchestrations for local parity, Infrastructure as Code pipelines, health endpoints per service.
 
 ## Dapr building blocks & messaging patterns
-- **Service invocation:** Each backend module exposes Dapr-invokable endpoints registered under `modular-monolith` or the extracted service ID.
-- **Pub/Sub:** Kafka topics follow the `<bounded-context>.<event>` naming convention; consumers rely on Dapr components defined under `src/*/Components/`.
-- **Bindings:** Outgoing email/SMS/webhook adapters are encapsulated in Dapr bindings to enable swapping providers without code changes.
-- **State store:** Ignite is accessed via the Dapr state store for cache-coherent operations between services.
+- **Service invocation:** Backend services are registered with Dapr in the Aspire AppHost (`src/AppHost/AppHost.cs`).
+- **Pub/Sub:** Kafka topics follow the `<bounded-context>.<event>` naming convention; component stubs live under `src/AppHost/mounts/dapr/components/` (currently empty placeholders that must be filled for local runs).
+- **Bindings:** Email dispatch uses the `Azure.Communication.Email` SDK directly; Dapr bindings are not configured yet.
+- **State store:** Ignite is provisioned as infrastructure but no Dapr state store configuration is defined in the repo.
 
 ## Data & storage strategy
-- **Operational data:** PostgreSQL/TimescaleDB instances per bounded context (schema-first migrations in `/src/*/Migrations`).
-- **Historical data:** Timescale hypertables store telemetry and analytics workloads with retention managed by policies.
-- **Caching:** Ignite serves as the distributed cache and secondary index for high-throughput reads.
-- **Secrets/configuration:** Development secrets live in `.env`/Aspire user secrets; production relies on Azure Key Vault or HashiCorp Vault (TBD).
+- **Operational data:** Identifier persists to PostgreSQL/TimescaleDB with EF Core migrations under `src/services/identifier/Identifier.Infrastructure/Migrations`.
+- **Historical data:** Streamer writes telemetry to Timescale using raw Npgsql commands.
+- **Caching:** Ignite is provisioned (Docker/Aspire) but not referenced by runtime code yet.
+- **Secrets/configuration:** Service settings live in `appsettings.json` with environment overrides; no Key Vault/Vault integration is configured in this repo.
 
 ## Development workflow highlights
 1. Design contracts and domain models in the targeted module (see [`docs/06-Modular-Architecture-Guidelines.md`](docs/06-Modular-Architecture-Guidelines.md)).
@@ -127,15 +121,15 @@ sequenceDiagram
     participant Sensor as Sensor Producer
     participant Streamer as Streamer Service
     participant Dapr as Dapr Pub/Sub
-    participant Monolith as modular-monolith
+    participant Notifier as Notifier Service
     participant Backend as web-backend-core
-    participant Frontend as web-core
+    participant Client as SignalR Client
     participant Operator as Operator
 
     Sensor->>Streamer: Push telemetry batch
     Streamer->>Dapr: Publish telemetry.ingested
-    Dapr->>Monolith: Deliver domain event
-    Monolith->>Backend: Invoke façade APIs / SignalR payloads
-    Backend->>Frontend: Broadcast realtime update
-    Frontend->>Operator: Surface dashboards & notifications
+    Dapr->>Notifier: Deliver telemetry event
+    Notifier->>Backend: Invoke SignalR hub
+    Backend->>Client: Broadcast realtime update
+    Client->>Operator: Surface dashboards & notifications
 ```

--- a/docs/01-Architecture-Policy.md
+++ b/docs/01-Architecture-Policy.md
@@ -4,7 +4,7 @@
 - Each bounded context follows DDD with Clean Architecture layering.
 - External contracts (gRPC, OpenAPI, event schema) live in `/contracts` and are published as CI artefacts.
 - Aspire and Dapr are the default for local orchestration and service invocation.
-- Infrastructure dependencies (Kafka, Timescale, Ignite) are managed as code (docker compose / Bicep TBD).
+- Infrastructure dependencies (Kafka, Timescale, Ignite) are managed as code (`docker-compose.yml` and Aspire AppHost). No Bicep/Terraform manifests are tracked yet.
 - The modular monolith provides the canonical integration surface; distributed services must preserve the same contracts and follow the [Modular Architecture Guidelines](06-Modular-Architecture-Guidelines.md).
 
 ## Layering & boundaries
@@ -31,6 +31,6 @@
 - Health checks must validate downstream dependencies (Kafka, Timescale, Ignite) and align with Kubernetes/Aspire readiness probes.
 
 ## Documentation & decision records
-- Any new architecture significant change requires an ADR stored under `docs/adr/` following the `YYYYMMDD-title.md` format.
+- Any new architecture significant change requires an ADR stored under `docs/adr/` following the existing `0001.md`, `0002.md` numbering pattern.
 - Update [architecture-overview](../architecture-overview.md) diagrams and README sections when the container or component topology changes.
 - Record contract-breaking changes in `ReleaseNotes/` and link them from module READMEs.

--- a/docs/04-Security-Policy.md
+++ b/docs/04-Security-Policy.md
@@ -1,9 +1,9 @@
 # Security Policy
 
 ## Controls
-- JWT tokens are signed with a rotatable key stored in Key Vault (placeholder implementation).
-- OpenFeature drives feature flags and licensing via a Dapr binding provider.
-- Timescale and Ignite access follows the principle of least privilege.
-- gRPC plus HTTPS are mandatory in production environments.
-- Secrets must never live in the repository; use CI/CD variables instead.
-- Modular monolith deployments inherit the same security controls as the distributed topology to maintain parity across environments.
+- JWT tokens are signed with a configurable key (`Auth:Jwt:SigningKey` in `core-web`), with a development default if no secret is provided.
+- OpenFeature is wired in `web-backend-core` with an in-memory provider; no external flag provider or Dapr binding is configured yet.
+- TimescaleDB credentials are injected via connection strings (environment overrides are supported).
+- gRPC endpoints (Identifier and Streamer) run alongside HTTP; HTTPS is a deployment concern and is not enforced by default in the repo.
+- Secrets must never live in the repository; use environment variables or secret stores in CI/CD.
+- Modular monolith deployments must keep the same auth/flag semantics as the distributed topology to preserve contract parity.

--- a/docs/05-Testing-Policy.md
+++ b/docs/05-Testing-Policy.md
@@ -2,25 +2,25 @@
 
 ## Coverage pillars
 - **Unit:** xUnit for .NET, Jasmine for Angular.
-- **Integration:** gRPC/HTTP tests with Testcontainers (Kafka, Timescale, Ignite) plus Playwright e2e suites executed in CI.
-- **Contract:** schema verification via `buf`/`spectral` (pipeline step TBD) triggered by `make contracts` and release workflows.
-- **E2E:** Playwright orchestrated against the docker compose profile and Aspire AppHost.
+- **Integration:** Identifier API tests use Testcontainers (Timescale/Postgres). Other services currently rely on unit tests only.
+- **Contract:** JSON schema validation uses `tests/Contracts/schema-validation.test.sh` (AJV in CI). `make contracts` only bundles the contracts directory.
+- **E2E:** Playwright spec under `tests/WebCore/e2e.spec.ts` targets a running `web-core` instance.
 - **Coverage goal:** minimum 70% for critical domains, including modules delivered through the modular monolith façade.
 
 ## Test environments
-- **Local:** `make test` spins up required containers and runs .NET/Angular unit tests. Integration tests rely on Testcontainers to remain hermetic.
-- **CI (pull requests):** Executes unit + integration tests, static analysis, contract validation, and publishes coverage reports.
-- **Nightly:** Full E2E suite against the docker compose topology with seeded sample data (`tools/scripts/generate-sample-data.sh`).
+- **Local:** `make test` runs `dotnet test` and `npm test` (it does not start containers). Integration tests that need databases spin up Testcontainers.
+- **CI (pull requests):** `pr-gate.yml` runs .NET build/test, frontend lint/tests, and JSON schema validation; coverage artefacts are uploaded.
+- **Nightly:** No nightly workflow is defined in `.github/workflows/` at the moment.
 
 ## Quality gates
 - Block merges when tests fail or coverage decreases beyond threshold.
-- Contracts must be regenerated (`make contracts`) and committed when proto/OpenAPI definitions change.
-- New modules require dedicated smoke tests proving integration with the modular monolith façade and web-core module manifest.
+- Contracts should be re-bundled (`make contracts`) and committed when proto/OpenAPI definitions change.
+- New modules should add smoke tests proving integration with the modular monolith façade and web-core module manifest.
 
 ## Tooling matrix
 | Layer | Backend | Frontend |
 | --- | --- | --- |
 | Unit | xUnit + FluentAssertions | Jasmine/Karma |
-| Integration | Testcontainers + Aspire orchestrations | Playwright component tests |
-| Contract | `buf`, `spectral`, JSON schema diff | API client generation smoke tests |
-| E2E | Playwright headless via docker compose | Playwright end-user journeys |
+| Integration | Testcontainers (Timescale/Postgres) | - |
+| Contract | AJV schema validation | - |
+| E2E | Playwright (manual orchestration) | Playwright end-user journeys |

--- a/docs/06-Modular-Architecture-Guidelines.md
+++ b/docs/06-Modular-Architecture-Guidelines.md
@@ -1,23 +1,23 @@
 # Modular Architecture Guidelines
 
 ## Contracts & boundaries
-- Each module exposes independent contracts in `/contracts/<module>` and registers its frontend entry point inside [`contracts/web-core/module-manifest.json`](../contracts/web-core/module-manifest.json).
+- Service contracts live under `/contracts/<service>` and frontend remotes are registered in [`contracts/web-core/module-manifest.json`](../contracts/web-core/module-manifest.json).
 - Shared use cases flow through the web-backend-core orchestrator via Dapr gRPC.
 - Module federation lets every micro-frontend expose its entry point as a remote.
 - Backend plug-ins register through Dapr service discovery.
-- The modular monolith hosts modules behind a unified façade; when extracting services, keep the same contracts to maintain backwards compatibility. Use existing examples such as [`modules/ticketing`](../modules/ticketing/README.md) as a baseline for additional plug-ins.
+- The modular monolith hosts modules behind a unified façade; when extracting services, keep the same contracts to maintain backwards compatibility. Use existing examples such as [`modules/ticketing`](../modules/ticketing/README.md) as a baseline for additional plug-ins (currently a contract-only sample).
 
 ## Module lifecycle checklist
 1. **Design:** Capture the bounded context, commands, queries, and events. Document assumptions in an ADR when required.
-2. **Contracts:** Define gRPC/OpenAPI schemas under `/contracts/<module>` and publish the manifest entry.
-3. **Backend implementation:** Implement Clean Architecture layers under `modules/<module>/src/*` or equivalent service project. Register Dapr components and health checks.
-4. **Frontend surface:** Provide a federated Angular remote packaged under `modules/<module>/web`. Register routes/components in the manifest.
+2. **Contracts:** Define gRPC/OpenAPI schemas under `/contracts/<service>` (or a module folder when introduced) and publish the manifest entry.
+3. **Backend implementation:** Implement Clean Architecture layers under `modules/<module>/src/*` or the dedicated service project. Register Dapr components and health checks.
+4. **Frontend surface:** Provide a federated Angular remote packaged under `modules/<module>/web` and register routes/components in the manifest.
 5. **Testing:** Add unit/integration/contract tests. Ensure Playwright smoke tests cover the module entry points.
 6. **Documentation:** Update module README, architecture overview, and release notes.
 
 ## Dapr registration
-- Register invocation endpoints in `Components/dapr.yaml` with consistent IDs (`module-<name>`).
-- Configure pub/sub topics via component files stored alongside the module. Apply dead-letter queues where necessary.
+- Register invocation endpoints in the Aspire AppHost and add Dapr components under `src/AppHost/mounts/dapr/components/`.
+- Configure pub/sub topics via component files in that directory and apply dead-letter queues where necessary.
 - For background processors, define Cron bindings or input bindings with clear naming and TTL policies.
 
 ## Observability expectations
@@ -27,5 +27,5 @@
 
 ## Deployment considerations
 - Modules packaged within the modular monolith should include feature toggles to gate unfinished capabilities.
-- When deploying as independent services, ship Helm/Bicep manifests referencing the shared infrastructure (Kafka topics, Timescale schemas, Ignite caches).
+- When deploying as independent services, document the infrastructure requirements (Kafka topics, Timescale schemas, Ignite caches) since no Helm/Bicep manifests are tracked here yet.
 - Document rollout steps (migrations, seed data, toggle activation) inside the module README and release notes.

--- a/docs/07-Observability-Guidelines.md
+++ b/docs/07-Observability-Guidelines.md
@@ -1,9 +1,14 @@
 # Observability Guidelines
 
 ## Telemetry baseline
-- OpenTelemetry SDK is configured in all services for metrics and traces.
-- Default export path: OTLP → Tempo, Prometheus scrape, Loki for logs.
-- Every service exposes `/healthz` and `/metrics` endpoints.
+- OpenTelemetry SDK is configured in the .NET services for traces; Prometheus metrics exporters are enabled where configured.
+- There is no OTLP exporter configured in code yet, so Tempo/Loki ingestion requires additional setup.
+- Health endpoints:
+  - `/healthz` for `identifier`, `streamer`, `notifier`, `web-backend-core`, `modular-monolith`.
+  - `/health` for `core-web`.
+- Metrics endpoints:
+  - `/metrics` is wired with Prometheus exporter in `identifier`.
+  - Other services expose `/metrics` as a placeholder string response today.
 - Grafana dashboards will be versioned under `observability/dashboards/` once the first dashboards are published (TODO).
 - Observability stack relies exclusively on OSS components (Prometheus, Loki, Tempo, Grafana OSS).
 - Modular monolith deployments emit the same telemetry envelopes to ensure consistent dashboards regardless of runtime topology.


### PR DESCRIPTION
### Motivation
- Align documentation with the repository code and runtime topologies (Aspire AppHost vs `docker compose`) to remove inaccurate claims about Dapr, caching, and feature flag bindings. 
- Surface concrete operational gaps and environment expectations such as ports, connection strings, and placeholder Dapr components so local runs are deterministic. 
- Provide a traceable discrepancy inventory and changelog to guide further documentation fixes. 

### Description
- Updated key docs to reflect code reality including `README.md`, `architecture-overview.md`, `docs/01-Architecture-Policy.md`, `docs/04-Security-Policy.md`, `docs/05-Testing-Policy.md`, `docs/06-Modular-Architecture-Guidelines.md`, `docs/07-Observability-Guidelines.md`, and `docs/identifier/README.md`. 
- Added `REPORT_DISCREPANZE.md` with inventory, reality map, mismatch table, plan-of-change, and a `Files to remove` / `Files added` summary, and created `CHANGELOG_DOCS.md` summarizing documentation updates. 
- Clarified runtime guidance that `make dev` uses `docker compose` (no Dapr sidecars) while `dotnet run --project src/AppHost/Momentum.AppHost.csproj` provisions Aspire AppHost with Dapr sidecars, and corrected service coverage and event flows (streamer → Timescale → Dapr/Kafka → notifier → `web-backend-core` SignalR). 
- Corrected `identifier` documentation to reference PostgreSQL/Timescale connection examples, updated example port (`localhost:8082`), Testcontainers usage for integration tests, and added Dapr seed-topic notes and requirement to supply `ConnectionStrings__Identifier` in compose. 

### Testing
- No automated tests were executed as part of this documentation-only change. 
- CI configuration remains unchanged and `.github/workflows/pr-gate.yml` continues to be configured to run .NET build/tests and JSON schema validation on PRs. 
- Recommend running the existing PR gate (`pr-gate.yml`) to validate that documentation edits do not alter pipeline expectations.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694ba13042508333a1773e26d4e7ad14)
- Closes #288 (commit ffa8ddf)